### PR TITLE
For basic getters and setters, use public fields instead

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ emscripten/target
 emscripten/Cargo.lock
 js/livesplit.js
 Cargo.lock
-**.rs.bk
+*.rs.bk
+*.swp

--- a/capi/src/run.rs
+++ b/capi/src/run.rs
@@ -120,7 +120,7 @@ pub unsafe extern "C" fn Run_len(this: *const Run) -> usize {
 
 #[no_mangle]
 pub unsafe extern "C" fn Run_segment(this: *const Run, index: usize) -> *const Segment {
-    acc(this).segments.get(index).unwrap_or(std::ptr::null())
+    acc(this).segments.get(index).map_or(ptr::null(), |p| p as *const Segment)
 }
 
 #[no_mangle]

--- a/capi/src/run.rs
+++ b/capi/src/run.rs
@@ -38,32 +38,36 @@ pub unsafe extern "C" fn Run_clone(this: *const Run) -> OwnedRun {
 
 #[no_mangle]
 pub unsafe extern "C" fn Run_push_segment(this: *mut Run, segment: OwnedSegment) {
-    acc_mut(this).push_segment(own(segment));
+    acc_mut(this).segments.push(own(segment));
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Run_game_name(this: *const Run) -> *const c_char {
-    output_str(acc(this).game_name())
+    output_str(&acc(this).game_name)
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Run_set_game_name(this: *mut Run, game: *const c_char) {
-    acc_mut(this).set_game_name(str(game));
+    let r = acc_mut(this);
+    r.game_name.clear();
+    r.game_name.push_str(str(game));
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Run_game_icon(this: *const Run) -> *const c_char {
-    output_str(acc(this).game_icon().url())
+    output_str(acc(this).game_icon.url())
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Run_category_name(this: *const Run) -> *const c_char {
-    output_str(acc(this).category_name())
+    output_str(&acc(this).category_name)
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Run_set_category_name(this: *mut Run, category: *const c_char) {
-    acc_mut(this).set_category_name(str(category));
+    let r = acc_mut(this);
+    r.category_name.clear();
+    r.category_name.push_str(str(category));
 }
 
 #[no_mangle]
@@ -96,17 +100,17 @@ pub unsafe extern "C" fn Run_extended_category_name(
 
 #[no_mangle]
 pub unsafe extern "C" fn Run_attempt_count(this: *const Run) -> u32 {
-    acc(this).attempt_count()
+    acc(this).attempt_count
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Run_metadata(this: *const Run) -> *const RunMetadata {
-    acc(this).metadata()
+    &acc(this).metadata
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Run_offset(this: *const Run) -> *const TimeSpan {
-    output_time_span(acc(this).offset())
+    output_time_span(acc(this).offset)
 }
 
 #[no_mangle]
@@ -116,7 +120,7 @@ pub unsafe extern "C" fn Run_len(this: *const Run) -> usize {
 
 #[no_mangle]
 pub unsafe extern "C" fn Run_segment(this: *const Run, index: usize) -> *const Segment {
-    acc(this).segment(index)
+    acc(this).segments.get(index).unwrap_or(std::ptr::null())
 }
 
 #[no_mangle]

--- a/capi/src/run_metadata.rs
+++ b/capi/src/run_metadata.rs
@@ -7,22 +7,22 @@ pub type OwnedRunMetadata = *mut RunMetadata;
 
 #[no_mangle]
 pub unsafe extern "C" fn RunMetadata_run_id(this: *const RunMetadata) -> *const c_char {
-    output_str(acc(this).run_id())
+    output_str(&acc(this).run_id)
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn RunMetadata_platform_name(this: *const RunMetadata) -> *const c_char {
-    output_str(acc(this).platform_name())
+    output_str(&acc(this).platform_name)
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn RunMetadata_uses_emulator(this: *const RunMetadata) -> bool {
-    acc(this).uses_emulator()
+    acc(this).uses_emulator
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn RunMetadata_region_name(this: *const RunMetadata) -> *const c_char {
-    output_str(acc(this).region_name())
+    output_str(&acc(this).region_name)
 }
 
 #[no_mangle]

--- a/capi/src/segment.rs
+++ b/capi/src/segment.rs
@@ -16,12 +16,12 @@ pub unsafe extern "C" fn Segment_drop(this: OwnedSegment) {
 
 #[no_mangle]
 pub unsafe extern "C" fn Segment_name(this: *const Segment) -> *const c_char {
-    output_str(acc(this).name())
+    output_str(&acc(this).name)
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Segment_icon(this: *const Segment) -> *const c_char {
-    output_str(acc(this).icon().url())
+    output_str(acc(this).icon.url())
 }
 
 #[no_mangle]
@@ -39,10 +39,10 @@ pub unsafe extern "C" fn Segment_personal_best_split_time(this: *const Segment) 
 
 #[no_mangle]
 pub unsafe extern "C" fn Segment_best_segment_time(this: *const Segment) -> *const Time {
-    output_time(acc(this).best_segment_time())
+    output_time(acc(this).best_segment_time)
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Segment_segment_history(this: *const Segment) -> *const SegmentHistory {
-    acc(this).segment_history()
+    &acc(this).segment_history
 }

--- a/src/analysis/current_pace.rs
+++ b/src/analysis/current_pace.rs
@@ -3,7 +3,7 @@ use analysis;
 
 pub fn calculate(timer: &Timer, comparison: &str) -> Option<TimeSpan> {
     let timing_method = timer.current_timing_method();
-    let last_segment = timer.run().segments().last().unwrap();
+    let last_segment = timer.run().segments.last().unwrap();
 
     match timer.current_phase() {
         TimerPhase::Running | TimerPhase::Paused => {

--- a/src/analysis/current_pace.rs
+++ b/src/analysis/current_pace.rs
@@ -27,7 +27,7 @@ pub fn calculate(timer: &Timer, comparison: &str) -> Option<TimeSpan> {
 
             last_segment.comparison(comparison)[timing_method].map(|c| delta + c)
         }
-        TimerPhase::Ended => last_segment.split_time()[timing_method],
+        TimerPhase::Ended => last_segment.split_time[timing_method],
         TimerPhase::NotRunning => last_segment.comparison(comparison)[timing_method],
     }
 }

--- a/src/analysis/delta.rs
+++ b/src/analysis/delta.rs
@@ -31,7 +31,7 @@ pub fn calculate(timer: &Timer, comparison: &str) -> (Option<TimeSpan>, bool) {
             delta
         }
         TimerPhase::Ended => TimeSpan::option_sub(
-            last_segment.split_time()[timing_method],
+            last_segment.split_time[timing_method],
             last_segment.comparison(comparison)[timing_method],
         ),
         TimerPhase::NotRunning => None,

--- a/src/analysis/delta.rs
+++ b/src/analysis/delta.rs
@@ -3,7 +3,7 @@ use analysis;
 
 pub fn calculate(timer: &Timer, comparison: &str) -> (Option<TimeSpan>, bool) {
     let timing_method = timer.current_timing_method();
-    let last_segment = timer.run().segments().last().unwrap();
+    let last_segment = timer.run().segments.last().unwrap();
 
     let mut use_live_delta = false;
 

--- a/src/analysis/possible_time_save.rs
+++ b/src/analysis/possible_time_save.rs
@@ -6,10 +6,10 @@ pub fn calculate(
     comparison: &str,
     live: bool,
 ) -> Option<TimeSpan> {
-    let segments = timer.run().segments();
+    let segments = &timer.run().segments;
     let method = timer.current_timing_method();
     let mut prev_time = TimeSpan::zero();
-    let segment = timer.run().segment(segment_index);
+    let segment = &timer.run().segments[segment_index];
     let mut best_segments = segment.best_segment_time()[method];
 
     for segment in segments[..segment_index].iter().rev() {

--- a/src/analysis/possible_time_save.rs
+++ b/src/analysis/possible_time_save.rs
@@ -10,14 +10,14 @@ pub fn calculate(
     let method = timer.current_timing_method();
     let mut prev_time = TimeSpan::zero();
     let segment = &timer.run().segments[segment_index];
-    let mut best_segments = segment.best_segment_time()[method];
+    let mut best_segments = segment.best_segment_time[method];
 
     for segment in segments[..segment_index].iter().rev() {
         if let Some(ref mut best_segments) = best_segments {
             if let Some(split_time) = segment.comparison(comparison)[method] {
                 prev_time = split_time;
                 break;
-            } else if let Some(best_segment) = segment.best_segment_time()[method] {
+            } else if let Some(best_segment) = segment.best_segment_time[method] {
                 *best_segments += best_segment;
             }
         } else {

--- a/src/analysis/state_helper.rs
+++ b/src/analysis/state_helper.rs
@@ -18,7 +18,7 @@ pub fn last_delta(
 ) -> Option<TimeSpan> {
     for segment in run.segments[..split_number + 1].iter().rev() {
         let comparison = segment.comparison_timing_method(comparison, method);
-        let split_time = segment.split_time()[method];
+        let split_time = segment.split_time[method];
         if let (Some(comparison), Some(split_time)) = (comparison, split_time) {
             return Some(split_time - comparison);
         }
@@ -37,7 +37,7 @@ fn segment_time_or_segment_delta(
     let current_time = if use_current_time {
         timer.current_time()[method]
     } else {
-        timer.run().segments[split_number].split_time()[method]
+        timer.run().segments[split_number].split_time[method]
     };
 
     if let Some(current_time) = current_time {
@@ -47,7 +47,7 @@ fn segment_time_or_segment_delta(
             .comparison_timing_method(comparison, method);
 
         for segment in timer.run().segments[..split_number].iter().rev() {
-            if let Some(split_time) = segment.split_time()[method] {
+            if let Some(split_time) = segment.split_time[method] {
                 if segment_time {
                     return Some(current_time - split_time);
                 } else if let Some(comparison) =
@@ -163,7 +163,7 @@ pub fn check_live_delta(
         let current_time = timer.current_time()[method];
         let split_index = timer.current_split_index() as usize;
         let current_segment = live_segment_time(timer, split_index, method);
-        let best_segment = timer.run().segments[split_index].best_segment_time()[method];
+        let best_segment = timer.run().segments[split_index].best_segment_time[method];
         let best_segment_delta =
             live_segment_delta(timer, split_index, best_segments::NAME, method);
         let comparison_delta = live_segment_delta(timer, split_index, comparison, method);
@@ -232,13 +232,13 @@ pub fn split_color(
 ///
 /// Returns whether or not the indicated split is a Best Segment.
 pub fn check_best_segment(timer: &Timer, split_number: usize, method: TimingMethod) -> bool {
-    if timer.run().segments[split_number].split_time()[method].is_none() {
+    if timer.run().segments[split_number].split_time[method].is_none() {
         return false;
     }
 
     let delta = previous_segment_delta(timer, split_number, best_segments::NAME, method);
     let current_segment = previous_segment_time(timer, split_number, method);
-    let best_segment = timer.run().segments[split_number].best_segment_time()[method];
+    let best_segment = timer.run().segments[split_number].best_segment_time[method];
     best_segment.map_or(true, |b| {
         current_segment.map_or(false, |c| c < b) || delta.map_or(false, |d| d < TimeSpan::zero())
     })

--- a/src/analysis/state_helper.rs
+++ b/src/analysis/state_helper.rs
@@ -16,7 +16,7 @@ pub fn last_delta(
     comparison: &str,
     method: TimingMethod,
 ) -> Option<TimeSpan> {
-    for segment in run.segments()[..split_number + 1].iter().rev() {
+    for segment in run.segments[..split_number + 1].iter().rev() {
         let comparison = segment.comparison_timing_method(comparison, method);
         let split_time = segment.split_time()[method];
         if let (Some(comparison), Some(split_time)) = (comparison, split_time) {
@@ -37,16 +37,16 @@ fn segment_time_or_segment_delta(
     let current_time = if use_current_time {
         timer.current_time()[method]
     } else {
-        timer.run().segment(split_number).split_time()[method]
+        timer.run().segments[split_number].split_time()[method]
     };
 
     if let Some(current_time) = current_time {
         let split_number_comparison = timer
             .run()
-            .segment(split_number)
+            .segments[split_number]
             .comparison_timing_method(comparison, method);
 
-        for segment in timer.run().segments()[..split_number].iter().rev() {
+        for segment in timer.run().segments[..split_number].iter().rev() {
             if let Some(split_time) = segment.split_time()[method] {
                 if segment_time {
                     return Some(current_time - split_time);
@@ -163,7 +163,7 @@ pub fn check_live_delta(
         let current_time = timer.current_time()[method];
         let split_index = timer.current_split_index() as usize;
         let current_segment = live_segment_time(timer, split_index, method);
-        let best_segment = timer.run().segment(split_index).best_segment_time()[method];
+        let best_segment = timer.run().segments[split_index].best_segment_time()[method];
         let best_segment_delta =
             live_segment_delta(timer, split_index, best_segments::NAME, method);
         let comparison_delta = live_segment_delta(timer, split_index, comparison, method);
@@ -232,13 +232,13 @@ pub fn split_color(
 ///
 /// Returns whether or not the indicated split is a Best Segment.
 pub fn check_best_segment(timer: &Timer, split_number: usize, method: TimingMethod) -> bool {
-    if timer.run().segment(split_number).split_time()[method].is_none() {
+    if timer.run().segments[split_number].split_time()[method].is_none() {
         return false;
     }
 
     let delta = previous_segment_delta(timer, split_number, best_segments::NAME, method);
     let current_segment = previous_segment_time(timer, split_number, method);
-    let best_segment = timer.run().segment(split_number).best_segment_time()[method];
+    let best_segment = timer.run().segments[split_number].best_segment_time()[method];
     best_segment.map_or(true, |b| {
         current_segment.map_or(false, |c| c < b) || delta.map_or(false, |d| d < TimeSpan::zero())
     })

--- a/src/analysis/sum_of_segments/best.rs
+++ b/src/analysis/sum_of_segments/best.rs
@@ -21,11 +21,11 @@ fn populate_predictions(
     if let Some(current_time) = current_time {
         populate_prediction(
             &mut predictions[segment_index + 1],
-            segments[segment_index].best_segment_time()[method].map(|t| t + current_time),
+            segments[segment_index].best_segment_time[method].map(|t| t + current_time),
         );
         if !simple_calculation {
             for &(null_segment_index, _) in segments[segment_index]
-                .segment_history()
+                .segment_history
                 .iter()
                 .filter(|&&(_, t)| t[method].is_none())
             {
@@ -34,7 +34,7 @@ fn populate_predictions(
                     .checked_sub(1)
                     .and_then(|previous_index| {
                         segments[previous_index]
-                            .segment_history()
+                            .segment_history
                             .get(null_segment_index)
                     })
                     .map_or(true, |segment_time| segment_time[method].is_some());

--- a/src/analysis/sum_of_segments/mod.rs
+++ b/src/analysis/sum_of_segments/mod.rs
@@ -47,10 +47,10 @@ fn track_current_run(
 ) -> (usize, Time) {
     if let Some(first_split_time) = segment_index
         .checked_sub(1)
-        .map_or(Some(TimeSpan::zero()), |i| segments[i].split_time()[method])
+        .map_or(Some(TimeSpan::zero()), |i| segments[i].split_time[method])
     {
         for (segment_index, segment) in segments.iter().enumerate().skip(segment_index) {
-            let second_split_time = segment.split_time()[method];
+            let second_split_time = segment.split_time[method];
             if let Some(second_split_time) = second_split_time {
                 return (
                     segment_index + 1,
@@ -99,7 +99,7 @@ pub fn track_branch(
     method: TimingMethod,
 ) -> (usize, Time) {
     for (segment_index, segment) in segments.iter().enumerate().skip(segment_index) {
-        if let Some(cur_time) = segment.segment_history().get(run_index) {
+        if let Some(cur_time) = segment.segment_history.get(run_index) {
             if let Some(cur_time) = cur_time[method] {
                 return (
                     segment_index + 1,

--- a/src/analysis/sum_of_segments/worst.rs
+++ b/src/analysis/sum_of_segments/worst.rs
@@ -20,14 +20,14 @@ fn populate_predictions(
     if let Some(current_time) = current_time {
         populate_prediction(
             &mut predictions[segment_index + 1],
-            segments[segment_index].best_segment_time()[method].map(|t| t + current_time),
+            segments[segment_index].best_segment_time[method].map(|t| t + current_time),
         );
-        for &(segment_history_index, _) in segments[segment_index].segment_history().iter() {
+        for &(segment_history_index, _) in segments[segment_index].segment_history.iter() {
             let should_track_branch = segment_index
                 .checked_sub(1)
                 .and_then(|previous_index| {
                     segments[previous_index]
-                        .segment_history()
+                        .segment_history
                         .get(segment_history_index)
                 })
                 .map_or(true, |segment_time| segment_time[method].is_some());

--- a/src/analysis/tests/empty_run.rs
+++ b/src/analysis/tests/empty_run.rs
@@ -6,19 +6,19 @@ use super::super::total_playtime;
 fn sum_of_best() {
     let run = Run::new();
     assert_eq!(
-        calculate_best(run.segments(), false, false, TimingMethod::RealTime),
+        calculate_best(&run.segments, false, false, TimingMethod::RealTime),
         Some(TimeSpan::zero())
     );
     assert_eq!(
-        calculate_best(run.segments(), false, true, TimingMethod::RealTime),
+        calculate_best(&run.segments, false, true, TimingMethod::RealTime),
         Some(TimeSpan::zero())
     );
     assert_eq!(
-        calculate_best(run.segments(), true, false, TimingMethod::RealTime),
+        calculate_best(&run.segments, true, false, TimingMethod::RealTime),
         Some(TimeSpan::zero())
     );
     assert_eq!(
-        calculate_best(run.segments(), true, true, TimingMethod::RealTime),
+        calculate_best(&run.segments, true, true, TimingMethod::RealTime),
         Some(TimeSpan::zero())
     );
 }
@@ -27,11 +27,11 @@ fn sum_of_best() {
 fn sum_of_worst() {
     let run = Run::new();
     assert_eq!(
-        calculate_worst(run.segments(), false, TimingMethod::RealTime),
+        calculate_worst(&run.segments, false, TimingMethod::RealTime),
         Some(TimeSpan::zero())
     );
     assert_eq!(
-        calculate_worst(run.segments(), true, TimingMethod::RealTime),
+        calculate_worst(&run.segments, true, TimingMethod::RealTime),
         Some(TimeSpan::zero())
     );
 }

--- a/src/analysis/total_playtime.rs
+++ b/src/analysis/total_playtime.rs
@@ -20,7 +20,7 @@ impl TotalPlaytime for Run {
                 // Calculate the sum of the segments for that run
                 for segment in &self.segments {
                     if let Some(segment_time) = segment
-                        .segment_history()
+                        .segment_history
                         .get(attempt.index())
                         .and_then(|s| s[TimingMethod::RealTime])
                     {

--- a/src/analysis/total_playtime.rs
+++ b/src/analysis/total_playtime.rs
@@ -18,7 +18,7 @@ impl TotalPlaytime for Run {
             } else {
                 // Must be < 1.6.0 and a reset
                 // Calculate the sum of the segments for that run
-                for segment in self.segments() {
+                for segment in &self.segments {
                     if let Some(segment_time) = segment
                         .segment_history()
                         .get(attempt.index())

--- a/src/comparison/average_segments.rs
+++ b/src/comparison/average_segments.rs
@@ -32,12 +32,12 @@ fn generate(buf: &mut Vec<(i32, TimeSpan)>, segments: &mut [Segment], method: Ti
         if total_time.is_some() {
             buf.clear();
 
-            for &(id, time) in segments[i].segment_history().iter_actual_runs() {
+            for &(id, time) in segments[i].segment_history.iter_actual_runs() {
                 if let Some(time) = time[method] {
                     let keep = i.checked_sub(1)
                         .and_then(|i| {
                             segments[i]
-                                .segment_history()
+                                .segment_history
                                 .get(id)
                                 .map(|t| t[method].is_some())
                         })

--- a/src/comparison/best_split_times.rs
+++ b/src/comparison/best_split_times.rs
@@ -13,7 +13,7 @@ fn generate(segments: &mut [Segment], attempts: &[Attempt], method: TimingMethod
         let mut total_time = TimeSpan::zero();
 
         for segment in segments.iter_mut() {
-            if let Some(time) = segment.segment_history().get(id) {
+            if let Some(time) = segment.segment_history.get(id) {
                 if let Some(time) = time[method] {
                     total_time += time;
 
@@ -36,7 +36,7 @@ impl ComparisonGenerator for BestSplitTimes {
 
     fn generate(&mut self, segments: &mut [Segment], attempts: &[Attempt]) {
         if !segments.is_empty() {
-            *segments[0].comparison_mut(NAME) = segments[0].best_segment_time();
+            *segments[0].comparison_mut(NAME) = segments[0].best_segment_time;
             for segment in &mut segments[1..] {
                 *segment.comparison_mut(NAME) = segment.personal_best_split_time();
             }

--- a/src/comparison/latest_run.rs
+++ b/src/comparison/latest_run.rs
@@ -10,7 +10,7 @@ pub const NAME: &str = "Latest Run";
 fn generate(segments: &mut [Segment], method: TimingMethod) {
     let mut attempt_id = None;
     for segment in segments.iter_mut().rev() {
-        if let Some(max_index) = segment.segment_history().try_get_max_index() {
+        if let Some(max_index) = segment.segment_history.try_get_max_index() {
             attempt_id = Some(max_index);
             break;
         }
@@ -21,7 +21,7 @@ fn generate(segments: &mut [Segment], method: TimingMethod) {
 
         let mut total_time = TimeSpan::zero();
         while let Some(segment) = remaining_segments.next() {
-            let segment_time = segment.segment_history().get(attempt_id).map(|t| t[method]);
+            let segment_time = segment.segment_history.get(attempt_id).map(|t| t[method]);
 
             let split_time = match segment_time {
                 Some(Some(segment_time)) => {

--- a/src/component/detailed_timer.rs
+++ b/src/component/detailed_timer.rs
@@ -320,21 +320,21 @@ fn calculate_comparison_time(
     last_split_index: usize,
 ) -> Option<TimeSpan> {
     if comparison == best_segments::NAME {
-        timer.run().segment(last_split_index).best_segment_time()[timing_method]
+        timer.run().segments[last_split_index].best_segment_time()[timing_method]
     } else if last_split_index == 0 {
         timer
             .run()
-            .segment(0)
+            .segments[0]
             .comparison_timing_method(comparison, timing_method)
     } else if timer.current_split_index() > 0 {
         TimeSpan::option_sub(
             timer
                 .run()
-                .segment(last_split_index)
+                .segments[last_split_index]
                 .comparison_timing_method(comparison, timing_method),
             timer
                 .run()
-                .segment(last_split_index - 1)
+                .segments[last_split_index - 1]
                 .comparison_timing_method(comparison, timing_method),
         )
     } else {
@@ -348,13 +348,13 @@ fn calculate_segment_time(
     last_split_index: usize,
 ) -> Option<TimeSpan> {
     let last_split = if last_split_index > 0 {
-        timer.run().segment(last_split_index - 1).split_time()[timing_method]
+        timer.run().segments[last_split_index - 1].split_time()[timing_method]
     } else {
         Some(TimeSpan::zero())
     };
 
     if timer.current_phase() == TimerPhase::NotRunning {
-        Some(timer.run().offset())
+        Some(timer.run().offset)
     } else {
         TimeSpan::option_sub(timer.current_time()[timing_method], last_split)
     }

--- a/src/component/detailed_timer.rs
+++ b/src/component/detailed_timer.rs
@@ -218,7 +218,7 @@ impl Component {
         let icon_change = if self.settings.display_icon {
             timer
                 .current_split()
-                .and_then(|s| s.icon().check_for_change(icon_id).map(str::to_owned))
+                .and_then(|s| s.icon.check_for_change(icon_id).map(str::to_owned))
         } else if *icon_id != 0 {
             *icon_id = 0;
             Some(String::new())
@@ -227,7 +227,7 @@ impl Component {
         };
 
         let segment_name = if self.settings.show_segment_name {
-            timer.current_split().map(|s| s.name().to_owned())
+            timer.current_split().map(|s| s.name.clone())
         } else {
             None
         };
@@ -320,7 +320,7 @@ fn calculate_comparison_time(
     last_split_index: usize,
 ) -> Option<TimeSpan> {
     if comparison == best_segments::NAME {
-        timer.run().segments[last_split_index].best_segment_time()[timing_method]
+        timer.run().segments[last_split_index].best_segment_time[timing_method]
     } else if last_split_index == 0 {
         timer
             .run()
@@ -348,7 +348,7 @@ fn calculate_segment_time(
     last_split_index: usize,
 ) -> Option<TimeSpan> {
     let last_split = if last_split_index > 0 {
-        timer.run().segments[last_split_index - 1].split_time()[timing_method]
+        timer.run().segments[last_split_index - 1].split_time[timing_method]
     } else {
         Some(TimeSpan::zero())
     };

--- a/src/component/graph.rs
+++ b/src/component/graph.rs
@@ -373,7 +373,7 @@ impl Component {
 
         if y + 1 != draw_info.deltas.len() {
             if let Some(split_time) =
-                timer.run().segment(y).split_time()[timer.current_timing_method()]
+                timer.run().segments[y].split_time()[timer.current_timing_method()]
             {
                 *width_one = (split_time.total_milliseconds() as f32 /
                     draw_info.final_split.total_milliseconds() as f32) *
@@ -397,7 +397,7 @@ impl Component {
         if y + 1 == draw_info.deltas.len() && draw_info.is_live_delta_active {
             *width_two = WIDTH;
         } else if let Some(split_time) =
-            timer.run().segment(y).split_time()[timer.current_timing_method()]
+            timer.run().segments[y].split_time()[timer.current_timing_method()]
         {
             *width_two = (split_time.total_milliseconds() as f32 /
                 draw_info.final_split.total_milliseconds() as f32) * WIDTH;
@@ -519,7 +519,7 @@ impl Component {
                     .unwrap_or_else(TimeSpan::zero);
             } else {
                 let timing_method = timer.current_timing_method();
-                for segment in timer.run().segments()[..timer.current_split_index() as usize]
+                for segment in timer.run().segments[..timer.current_split_index() as usize]
                     .iter()
                     .rev()
                 {
@@ -534,7 +534,7 @@ impl Component {
 
     fn calculate_deltas(&self, timer: &Timer, comparison: &str, draw_info: &mut DrawInfo) {
         let timing_method = timer.current_timing_method();
-        for segment in timer.run().segments() {
+        for segment in &timer.run().segments {
             let time = TimeSpan::option_sub(
                 segment.split_time()[timing_method],
                 segment.comparison(comparison)[timing_method],

--- a/src/component/graph.rs
+++ b/src/component/graph.rs
@@ -373,7 +373,7 @@ impl Component {
 
         if y + 1 != draw_info.deltas.len() {
             if let Some(split_time) =
-                timer.run().segments[y].split_time()[timer.current_timing_method()]
+                timer.run().segments[y].split_time[timer.current_timing_method()]
             {
                 *width_one = (split_time.total_milliseconds() as f32 /
                     draw_info.final_split.total_milliseconds() as f32) *
@@ -397,7 +397,7 @@ impl Component {
         if y + 1 == draw_info.deltas.len() && draw_info.is_live_delta_active {
             *width_two = WIDTH;
         } else if let Some(split_time) =
-            timer.run().segments[y].split_time()[timer.current_timing_method()]
+            timer.run().segments[y].split_time[timer.current_timing_method()]
         {
             *width_two = (split_time.total_milliseconds() as f32 /
                 draw_info.final_split.total_milliseconds() as f32) * WIDTH;
@@ -523,7 +523,7 @@ impl Component {
                     .iter()
                     .rev()
                 {
-                    if let Some(time) = segment.split_time()[timing_method] {
+                    if let Some(time) = segment.split_time[timing_method] {
                         draw_info.final_split = time;
                         return;
                     }
@@ -536,7 +536,7 @@ impl Component {
         let timing_method = timer.current_timing_method();
         for segment in &timer.run().segments {
             let time = TimeSpan::option_sub(
-                segment.split_time()[timing_method],
+                segment.split_time[timing_method],
                 segment.comparison(comparison)[timing_method],
             );
             if let Some(time) = time {

--- a/src/component/splits.rs
+++ b/src/component/splits.rs
@@ -146,7 +146,7 @@ impl Component {
         State {
             splits: timer
                 .run()
-                .segments()
+                .segments
                 .iter()
                 .enumerate()
                 .skip(skip_count)

--- a/src/component/splits.rs
+++ b/src/component/splits.rs
@@ -156,7 +156,7 @@ impl Component {
                         (always_show_last_split && i + 1 == timer.run().len())
                 })
                 .map(|((i, segment), icon_id)| {
-                    let split = segment.split_time()[method];
+                    let split = segment.split_time[method];
                     let comparison_time = segment.comparison(comparison)[method];
 
                     let (time, delta, semantic_color) = if current_split > i as isize {
@@ -189,8 +189,8 @@ impl Component {
                     let visual_color = semantic_color.visualize(layout_settings);
 
                     SplitState {
-                        icon_change: segment.icon().check_for_change(icon_id).map(str::to_owned),
-                        name: segment.name().to_string(),
+                        icon_change: segment.icon.check_for_change(icon_id).map(str::to_owned),
+                        name: segment.name.clone(),
                         delta,
                         time: Regular::new().format(time).to_string(),
                         semantic_color,

--- a/src/component/sum_of_best.rs
+++ b/src/component/sum_of_best.rs
@@ -70,7 +70,7 @@ impl Component {
 
     pub fn state(&self, timer: &Timer) -> State {
         let time = calculate_best(
-            timer.run().segments(),
+            &timer.run().segments,
             false,
             true,
             timer.current_timing_method(),

--- a/src/component/timer.rs
+++ b/src/component/timer.rs
@@ -108,7 +108,7 @@ impl Component {
             TimerPhase::Ended => {
                 let pb_time = timer
                     .run()
-                    .segments()
+                    .segments
                     .last()
                     .unwrap()
                     .comparison(current_comparison)[method];

--- a/src/component/title.rs
+++ b/src/component/title.rs
@@ -106,13 +106,13 @@ impl Component {
         };
 
         let attempts = if self.settings.show_attempt_count {
-            Some(run.attempt_count())
+            Some(run.attempt_count)
         } else {
             None
         };
 
         let icon_change = if self.settings.display_game_icon {
-            run.game_icon()
+            run.game_icon
                 .check_for_change(&mut self.icon_id)
                 .map(str::to_owned)
         } else if self.icon_id != 0 {
@@ -122,11 +122,11 @@ impl Component {
             None
         };
 
-        let is_centered = self.settings.center_text || run.game_icon().is_empty() ||
+        let is_centered = self.settings.center_text || run.game_icon.is_empty() ||
             !self.settings.display_game_icon;
 
         let game_name = if self.settings.show_game_name {
-            run.game_name()
+            &run.game_name
         } else {
             ""
         };

--- a/src/run/editor/cleaning.rs
+++ b/src/run/editor/cleaning.rs
@@ -62,12 +62,12 @@ impl<'r> fmt::Display for PotentialCleanUp<'r> {
         )?;
 
         if let Some(starting_segment) = self.starting_segment {
-            write!(f, "{}", starting_segment.name())?;
+            write!(f, "{}", starting_segment.name)?;
         } else {
             write!(f, "the start of the run")?;
         }
 
-        write!(f, " and {}", self.ending_segment.name())?;
+        write!(f, " and {}", self.ending_segment.name)?;
 
         if let Some(combined) = self.combined_sum_of_best {
             write!(
@@ -111,7 +111,7 @@ impl<'r> SumOfBestCleaner<'r> {
     pub fn apply(&mut self, clean_up: CleanUp) {
         self.run
             .segments[clean_up.ending_index]
-            .segment_history_mut()
+            .segment_history
             .remove(clean_up.run_index);
 
         self.run.mark_as_changed();
@@ -146,7 +146,7 @@ impl<'r> SumOfBestCleaner<'r> {
                 State::IteratingHistory(state) => {
                     let iter = self.run
                         .segments[state.parent.segment_index]
-                        .segment_history()
+                        .segment_history
                         .iter()
                         .enumerate()
                         .skip(state.skip_count);
@@ -201,7 +201,7 @@ fn check_prediction<'a>(
     if let Some(predicted_time) = predicted_time {
         if predictions[ending_index + 1].map_or(true, |t| predicted_time < t) {
             if let Some(segment_history_element) =
-                run.segments[ending_index].segment_history().get(run_index)
+                run.segments[ending_index].segment_history.get(run_index)
             {
                 return Some(PotentialCleanUp {
                     starting_segment: if starting_index >= 0 {

--- a/src/run/editor/cleaning.rs
+++ b/src/run/editor/cleaning.rs
@@ -110,7 +110,7 @@ impl<'r> SumOfBestCleaner<'r> {
 
     pub fn apply(&mut self, clean_up: CleanUp) {
         self.run
-            .segment_mut(clean_up.ending_index)
+            .segments[clean_up.ending_index]
             .segment_history_mut()
             .remove(clean_up.run_index);
 
@@ -145,7 +145,7 @@ impl<'r> SumOfBestCleaner<'r> {
                 }
                 State::IteratingHistory(state) => {
                     let iter = self.run
-                        .segment(state.parent.segment_index)
+                        .segments[state.parent.segment_index]
                         .segment_history()
                         .iter()
                         .enumerate()
@@ -154,7 +154,7 @@ impl<'r> SumOfBestCleaner<'r> {
                     for (skip_count, &(run_index, time)) in iter {
                         if time[state.parent.method].is_none() {
                             let (prediction_index, prediction_time) = track_branch(
-                                self.run.segments(),
+                                &self.run.segments,
                                 state.current_time,
                                 state.parent.segment_index + 1,
                                 run_index,
@@ -201,15 +201,15 @@ fn check_prediction<'a>(
     if let Some(predicted_time) = predicted_time {
         if predictions[ending_index + 1].map_or(true, |t| predicted_time < t) {
             if let Some(segment_history_element) =
-                run.segment(ending_index).segment_history().get(run_index)
+                run.segments[ending_index].segment_history().get(run_index)
             {
                 return Some(PotentialCleanUp {
                     starting_segment: if starting_index >= 0 {
-                        Some(run.segment(starting_index as usize))
+                        Some(&run.segments[starting_index as usize])
                     } else {
                         None
                     },
-                    ending_segment: run.segment(ending_index),
+                    ending_segment: &run.segments[ending_index],
                     time_between: segment_history_element[method]
                         .expect("Cleanup path is shorter but doesn't have a time"),
                     combined_sum_of_best: predictions[ending_index + 1].map(|t| {
@@ -234,7 +234,7 @@ fn check_prediction<'a>(
 }
 
 fn next_timing_method(run: &Run, predictions: &mut Vec<Option<TimeSpan>>, method: TimingMethod) {
-    let segments = run.segments();
+    let segments = &run.segments;
 
     predictions.clear();
     predictions.resize(segments.len() + 1, None);

--- a/src/run/editor/mod.rs
+++ b/src/run/editor/mod.rs
@@ -193,7 +193,7 @@ impl Editor {
         if pb_split_time.real_time != self.previous_personal_best_time.real_time ||
             pb_split_time.game_time != self.previous_personal_best_time.game_time
         {
-            self.run.metadata.set_run_id("");
+            self.run.metadata.run_id.clear();
             self.previous_personal_best_time = pb_split_time;
         }
         self.raise_run_edited();

--- a/src/run/editor/mod.rs
+++ b/src/run/editor/mod.rs
@@ -542,7 +542,8 @@ impl Editor {
                 .position(|c| c == old)
                 .ok_or(())?;
 
-            self.run.custom_comparisons[position] = new.to_string();
+            self.run.custom_comparisons[position].clear();
+            self.run.custom_comparisons[position].push_str(new);
 
             for segment in &mut self.run.segments {
                 if let Some(time) = segment.comparisons.remove(old) {

--- a/src/run/editor/segment_row.rs
+++ b/src/run/editor/segment_row.rs
@@ -15,28 +15,28 @@ impl<'a> SegmentRow<'a> {
     }
 
     pub fn icon(&self) -> &Image {
-        self.editor.run.segment(self.index).icon()
+        self.editor.run.segments[self.index].icon()
     }
 
     pub fn set_icon<D: Into<Image>>(&mut self, image: D) {
-        self.editor.run.segment_mut(self.index).set_icon(image);
+        self.editor.run.segments[self.index].set_icon(image);
         self.editor.raise_run_edited();
     }
 
     pub fn remove_icon(&mut self) {
-        self.editor.run.segment_mut(self.index).set_icon(&[]);
+        self.editor.run.segments[self.index].set_icon(&[]);
         self.editor.raise_run_edited();
     }
 
     pub fn name(&self) -> &str {
-        self.editor.run.segment(self.index).name()
+        self.editor.run.segments[self.index].name()
     }
 
     pub fn set_name<S>(&mut self, name: S)
     where
         S: AsRef<str>,
     {
-        self.editor.run.segment_mut(self.index).set_name(name);
+        self.editor.run.segments[self.index].set_name(name);
         self.editor.raise_run_edited();
     }
 
@@ -44,7 +44,7 @@ impl<'a> SegmentRow<'a> {
         let method = self.editor.selected_method;
         self.editor
             .run
-            .segment(self.index)
+            .segments[self.index]
             .personal_best_split_time()[method]
     }
 
@@ -52,7 +52,7 @@ impl<'a> SegmentRow<'a> {
         let method = self.editor.selected_method;
         self.editor
             .run
-            .segment_mut(self.index)
+            .segments[self.index]
             .personal_best_split_time_mut()[method] = time;
         self.editor.times_modified();
         self.editor.fix();
@@ -87,14 +87,14 @@ impl<'a> SegmentRow<'a> {
 
     pub fn best_segment_time(&self) -> Option<TimeSpan> {
         let method = self.editor.selected_method;
-        self.editor.run.segment(self.index).best_segment_time()[method]
+        self.editor.run.segments[self.index].best_segment_time()[method]
     }
 
     pub fn set_best_segment_time(&mut self, time: Option<TimeSpan>) {
         let method = self.editor.selected_method;
         self.editor
             .run
-            .segment_mut(self.index)
+            .segments[self.index]
             .best_segment_time_mut()[method] = time;
         self.editor.times_modified();
         self.editor.fix();
@@ -110,14 +110,14 @@ impl<'a> SegmentRow<'a> {
 
     pub fn comparison_time(&self, comparison: &str) -> Option<TimeSpan> {
         let method = self.editor.selected_method;
-        self.editor.run.segment(self.index).comparison(comparison)[method]
+        self.editor.run.segments[self.index].comparison(comparison)[method]
     }
 
     pub fn set_comparison_time(&mut self, comparison: &str, time: Option<TimeSpan>) {
         let method = self.editor.selected_method;
         self.editor
             .run
-            .segment_mut(self.index)
+            .segments[self.index]
             .comparison_mut(comparison)[method] = time;
         self.editor.times_modified();
         self.editor.fix();

--- a/src/run/editor/segment_row.rs
+++ b/src/run/editor/segment_row.rs
@@ -15,28 +15,29 @@ impl<'a> SegmentRow<'a> {
     }
 
     pub fn icon(&self) -> &Image {
-        self.editor.run.segments[self.index].icon()
+        &self.editor.run.segments[self.index].icon
     }
 
     pub fn set_icon<D: Into<Image>>(&mut self, image: D) {
-        self.editor.run.segments[self.index].set_icon(image);
+        self.editor.run.segments[self.index].icon = image.into();
         self.editor.raise_run_edited();
     }
 
     pub fn remove_icon(&mut self) {
-        self.editor.run.segments[self.index].set_icon(&[]);
+        self.editor.run.segments[self.index].icon = Image::default();
         self.editor.raise_run_edited();
     }
 
     pub fn name(&self) -> &str {
-        self.editor.run.segments[self.index].name()
+        &self.editor.run.segments[self.index].name
     }
 
     pub fn set_name<S>(&mut self, name: S)
     where
         S: AsRef<str>,
     {
-        self.editor.run.segments[self.index].set_name(name);
+        self.editor.run.segments[self.index].name.clear();
+        self.editor.run.segments[self.index].name.push_str(name.as_ref());
         self.editor.raise_run_edited();
     }
 
@@ -87,7 +88,7 @@ impl<'a> SegmentRow<'a> {
 
     pub fn best_segment_time(&self) -> Option<TimeSpan> {
         let method = self.editor.selected_method;
-        self.editor.run.segments[self.index].best_segment_time()[method]
+        self.editor.run.segments[self.index].best_segment_time[method]
     }
 
     pub fn set_best_segment_time(&mut self, time: Option<TimeSpan>) {
@@ -95,7 +96,7 @@ impl<'a> SegmentRow<'a> {
         self.editor
             .run
             .segments[self.index]
-            .best_segment_time_mut()[method] = time;
+            .best_segment_time[method] = time;
         self.editor.times_modified();
         self.editor.fix();
     }

--- a/src/run/editor/state.rs
+++ b/src/run/editor/state.rs
@@ -95,7 +95,7 @@ impl Editor {
 
             let icon_change = self.run
                 .segments[segment_index]
-                .icon()
+                .icon
                 .check_for_change(&mut self.segment_icon_ids[segment_index])
                 .map(str::to_owned);
 

--- a/src/run/editor/state.rs
+++ b/src/run/editor/state.rs
@@ -57,7 +57,7 @@ impl Editor {
         let formatter = EmptyWrapper::new(Short::with_accuracy(Accuracy::Hundredths));
 
         let icon_change = self.run
-            .game_icon()
+            .game_icon
             .check_for_change(&mut self.game_icon_id)
             .map(str::to_owned);
         let game = self.game_name().to_string();
@@ -94,7 +94,7 @@ impl Editor {
             }
 
             let icon_change = self.run
-                .segment(segment_index)
+                .segments[segment_index]
                 .icon()
                 .check_for_change(&mut self.segment_icon_ids[segment_index])
                 .map(str::to_owned);

--- a/src/run/editor/tests.rs
+++ b/src/run/editor/tests.rs
@@ -40,7 +40,7 @@ fn new_best_segment() {
         Some("1:00".parse().unwrap())
     );
     assert_eq!(
-        run.segments[0].best_segment_time().real_time,
+        run.segments[0].best_segment_time.real_time,
         Some("1:00".parse().unwrap())
     );
     assert_eq!(
@@ -48,7 +48,7 @@ fn new_best_segment() {
         Some("2:00".parse().unwrap())
     );
     assert_eq!(
-        run.segments[1].best_segment_time().real_time,
+        run.segments[1].best_segment_time.real_time,
         Some("1:00".parse().unwrap())
     );
     assert_eq!(
@@ -56,7 +56,7 @@ fn new_best_segment() {
         Some("3:00".parse().unwrap())
     );
     assert_eq!(
-        run.segments[2].best_segment_time().real_time,
+        run.segments[2].best_segment_time.real_time,
         Some("0:30".parse().unwrap())
     );
 }

--- a/src/run/editor/tests.rs
+++ b/src/run/editor/tests.rs
@@ -4,8 +4,8 @@ use super::Editor;
 #[test]
 fn new_best_segment() {
     let mut run = Run::new();
-    run.push_segment(Segment::new(""));
-    run.push_segment(Segment::new(""));
+    run.segments.push(Segment::new(""));
+    run.segments.push(Segment::new(""));
 
     let mut editor = Editor::new(run).unwrap();
 
@@ -36,27 +36,27 @@ fn new_best_segment() {
     let run = editor.close();
 
     assert_eq!(
-        run.segment(0).personal_best_split_time().real_time,
+        run.segments[0].personal_best_split_time().real_time,
         Some("1:00".parse().unwrap())
     );
     assert_eq!(
-        run.segment(0).best_segment_time().real_time,
+        run.segments[0].best_segment_time().real_time,
         Some("1:00".parse().unwrap())
     );
     assert_eq!(
-        run.segment(1).personal_best_split_time().real_time,
+        run.segments[1].personal_best_split_time().real_time,
         Some("2:00".parse().unwrap())
     );
     assert_eq!(
-        run.segment(1).best_segment_time().real_time,
+        run.segments[1].best_segment_time().real_time,
         Some("1:00".parse().unwrap())
     );
     assert_eq!(
-        run.segment(2).personal_best_split_time().real_time,
+        run.segments[2].personal_best_split_time().real_time,
         Some("3:00".parse().unwrap())
     );
     assert_eq!(
-        run.segment(2).best_segment_time().real_time,
+        run.segments[2].best_segment_time().real_time,
         Some("0:30".parse().unwrap())
     );
 }

--- a/src/run/parser/face_split.rs
+++ b/src/run/parser/face_split.rs
@@ -50,9 +50,9 @@ pub fn parse<R: BufRead>(source: R, load_icons: bool) -> Result<Run> {
     let mut icon_buf = Vec::new();
     let mut lines = source.lines();
 
-    run.set_category_name(lines.next().ok_or(Error::ExpectedTitle)??);
+    run.category_name = lines.next().ok_or(Error::ExpectedTitle)??;
     lines.next(); // TODO Store Goal
-    run.set_attempt_count(lines.next().ok_or(Error::ExpectedAttemptCount)??.parse()?);
+    run.attempt_count = lines.next().ok_or(Error::ExpectedAttemptCount)??.parse()?;
     lines.next(); // TODO Store runs completed somehow
 
     for line in lines {
@@ -84,7 +84,7 @@ pub fn parse<R: BufRead>(source: R, load_icons: bool) -> Result<Run> {
             }
         }
 
-        run.push_segment(segment);
+        run.segments.push(segment);
     }
 
     Ok(run)

--- a/src/run/parser/face_split.rs
+++ b/src/run/parser/face_split.rs
@@ -70,7 +70,7 @@ pub fn parse<R: BufRead>(source: R, load_icons: bool) -> Result<Run> {
         segment.set_personal_best_split_time(split_time);
 
         let best_segment = parse_time(splits.next().ok_or(Error::ExpectedBestSegmentTime)?)?;
-        segment.set_best_segment_time(best_segment);
+        segment.best_segment_time = best_segment;
 
         splits.next(); // Skip Segment Time
 
@@ -78,7 +78,7 @@ pub fn parse<R: BufRead>(source: R, load_icons: bool) -> Result<Run> {
             if let Some(icon_path) = splits.next() {
                 if !icon_path.is_empty() {
                     if let Ok(image) = Image::from_file(icon_path, &mut icon_buf) {
-                        segment.set_icon(image);
+                        segment.icon = image;
                     }
                 }
             }

--- a/src/run/parser/livesplit.rs
+++ b/src/run/parser/livesplit.rs
@@ -228,7 +228,7 @@ pub fn parse<R: Read>(source: R, path: Option<PathBuf>) -> Result<Run> {
     };
 
     if version >= Version(1, 6, 0, 0) {
-        let metadata = run.metadata_mut();
+        let metadata = &mut run.metadata;
         let node = child(&node, "Metadata")?;
 
         metadata.set_run_id(attribute(&child(&node, "Run")?, "id")?);
@@ -245,11 +245,11 @@ pub fn parse<R: Read>(source: R, path: Option<PathBuf>) -> Result<Run> {
         }
     }
 
-    run.set_game_icon(image(&child(&node, "GameIcon")?, icon_buf, buf));
-    run.set_game_name(text(&child(&node, "GameName")?, buf));
-    run.set_category_name(text(&child(&node, "CategoryName")?, buf));
-    run.set_offset(time_span(&child(&node, "Offset")?, buf)?);
-    run.set_attempt_count(text(&child(&node, "AttemptCount")?, buf).parse()?);
+    run.game_icon = image(&child(&node, "GameIcon")?, icon_buf, buf).into();
+    run.game_name = text(&child(&node, "GameName")?, buf).to_string();
+    run.category_name = text(&child(&node, "CategoryName")?, buf).to_string();
+    run.offset = time_span(&child(&node, "Offset")?, buf)?;
+    run.attempt_count = text(&child(&node, "AttemptCount")?, buf).parse()?;
 
     parse_attempt_history(version, &node, &mut run, buf)?;
 
@@ -300,7 +300,7 @@ pub fn parse<R: Read>(source: R, path: Option<PathBuf>) -> Result<Run> {
             segment.segment_history_mut().insert(index, time);
         }
 
-        run.push_segment(segment);
+        run.segments.push(segment);
     }
 
     if version >= Version(1, 4, 2, 0) {
@@ -308,7 +308,7 @@ pub fn parse<R: Read>(source: R, path: Option<PathBuf>) -> Result<Run> {
         // TODO Store this somehow
     }
 
-    run.set_path(path);
+    run.path = path;
 
     Ok(run)
 }

--- a/src/run/parser/livesplit.rs
+++ b/src/run/parser/livesplit.rs
@@ -257,7 +257,7 @@ pub fn parse<R: Read>(source: R, path: Option<PathBuf>) -> Result<Run> {
 
     for node in segments.children().into_iter().filter_map(|c| c.element()) {
         let mut segment = Segment::new(text(&child(&node, "Name")?, buf));
-        segment.set_icon(image(&child(&node, "Icon")?, icon_buf, buf));
+        segment.icon = image(&child(&node, "Icon")?, icon_buf, buf).into();
 
         if version >= Version(1, 3, 0, 0) {
             let node = child(&node, "SplitTimes")?;
@@ -281,11 +281,11 @@ pub fn parse<R: Read>(source: R, path: Option<PathBuf>) -> Result<Run> {
 
         let gold_split = child(&node, "BestSegmentTime")?;
         if !gold_split.children().is_empty() {
-            segment.set_best_segment_time(if version >= Version(1, 4, 1, 0) {
+            segment.best_segment_time = if version >= Version(1, 4, 1, 0) {
                 time(&gold_split, buf)?
             } else {
                 time_old(&gold_split, buf)?
-            });
+            };
         }
 
         let history = child(&node, "SegmentHistory")?;
@@ -297,7 +297,7 @@ pub fn parse<R: Read>(source: R, path: Option<PathBuf>) -> Result<Run> {
                 time_old(&node, buf)?
             };
 
-            segment.segment_history_mut().insert(index, time);
+            segment.segment_history.insert(index, time);
         }
 
         run.segments.push(segment);

--- a/src/run/parser/livesplit.rs
+++ b/src/run/parser/livesplit.rs
@@ -231,11 +231,11 @@ pub fn parse<R: Read>(source: R, path: Option<PathBuf>) -> Result<Run> {
         let metadata = &mut run.metadata;
         let node = child(&node, "Metadata")?;
 
-        metadata.set_run_id(attribute(&child(&node, "Run")?, "id")?);
+        metadata.run_id = attribute(&child(&node, "Run")?, "id")?.to_string();
         let platform = child(&node, "Platform")?;
-        metadata.set_platform_name(text(&platform, buf));
-        metadata.set_emulator_usage(parse_bool(attribute(&platform, "usesEmulator")?)?);
-        metadata.set_region_name(text(&child(&node, "Region")?, buf));
+        metadata.platform_name = text(&platform, buf).to_string();
+        metadata.uses_emulator = parse_bool(attribute(&platform, "usesEmulator")?)?;
+        metadata.region_name = text(&child(&node, "Region")?, buf).to_string();
 
         let variables = child(&node, "Variables")?;
         for variable in variables.children().into_iter().filter_map(|c| c.element()) {

--- a/src/run/parser/llanfair.rs
+++ b/src/run/parser/llanfair.rs
@@ -133,7 +133,7 @@ pub fn parse<R: Read + Seek>(mut source: R) -> Result<Run> {
         let mut segment = Segment::new(read_string(&mut source, &mut buf, total_len)?);
 
         if let Some(icon) = icon {
-            segment.set_icon(icon);
+            segment.icon = icon;
         }
 
         // Read the segment time
@@ -158,7 +158,7 @@ pub fn parse<R: Read + Seek>(mut source: R) -> Result<Run> {
             segment.set_personal_best_split_time(split_time);
         }
 
-        segment.set_best_segment_time(to_time(best_segment_ms));
+        segment.best_segment_time = to_time(best_segment_ms);
 
         run.segments.push(segment);
 

--- a/src/run/parser/llanfair.rs
+++ b/src/run/parser/llanfair.rs
@@ -50,11 +50,11 @@ pub fn parse<R: Read + Seek>(mut source: R) -> Result<Run> {
 
     // Skip to the goal string
     source.seek(SeekFrom::Start(0xc5))?;
-    run.set_category_name(read_string(&mut source, &mut buf, total_len)?);
+    run.category_name = read_string(&mut source, &mut buf, total_len)?.to_string();
 
     // Skip to the title string
     source.read_u8()?;
-    run.set_game_name(read_string(&mut source, &mut buf, total_len)?);
+    run.game_name = read_string(&mut source, &mut buf, total_len)?.to_string();
 
     source.seek(SeekFrom::Current(0x6))?;
     let segment_count = source.read_u32::<BE>()?;
@@ -160,7 +160,7 @@ pub fn parse<R: Read + Seek>(mut source: R) -> Result<Run> {
 
         segment.set_best_segment_time(to_time(best_segment_ms));
 
-        run.push_segment(segment);
+        run.segments.push(segment);
 
         // Seek to the beginning of the next segment name
         source.seek(SeekFrom::Current(0x6))?;

--- a/src/run/parser/llanfair2.rs
+++ b/src/run/parser/llanfair2.rs
@@ -119,7 +119,7 @@ pub fn parse<R: Read>(mut source: R) -> Result<Run> {
         let mut segment = Segment::new(child(&node, "name").ok().map_or("", |n| text(&n, buf)));
 
         if let Ok(image) = image(&node, &mut byte_buf, &mut byte_buf2, buf) {
-            segment.set_icon(image);
+            segment.icon = image.into();
         }
 
         if let Ok(node) = child(&node, "time") {
@@ -127,7 +127,7 @@ pub fn parse<R: Read>(mut source: R) -> Result<Run> {
         }
 
         if let Ok(node) = child(&node, "best") {
-            segment.set_best_segment_time(time(&node, buf)?);
+            segment.best_segment_time = time(&node, buf)?;
         }
 
         run.segments.push(segment);

--- a/src/run/parser/llanfair2.rs
+++ b/src/run/parser/llanfair2.rs
@@ -105,13 +105,13 @@ pub fn parse<R: Read>(mut source: R) -> Result<Run> {
         run.category_name = text(&node, buf).to_string();
     }
     if let Ok(node) = child(&node, "platform") {
-        run.metadata.set_platform_name(text(&node, buf));
+        run.metadata.platform_name = text(&node, buf).to_string();
     }
     if let Ok(node) = child(&node, "region") {
-        run.metadata.set_region_name(text(&node, buf));
+        run.metadata.region_name = text(&node, buf).to_string();
     }
     run.metadata
-        .set_emulator_usage(text(&child(&node, "emulated")?, buf) == "true");
+        .uses_emulator = text(&child(&node, "emulated")?, buf) == "true";
 
     let segments = child(&node, "segments")?;
 

--- a/src/run/parser/llanfair2.rs
+++ b/src/run/parser/llanfair2.rs
@@ -99,18 +99,18 @@ pub fn parse<R: Read>(mut source: R) -> Result<Run> {
     let mut run = Run::new();
 
     if let Ok(node) = child(&node, "game") {
-        run.set_game_name(text(&node, buf));
+        run.game_name = text(&node, buf).to_string();
     }
     if let Ok(node) = child(&node, "category") {
-        run.set_category_name(text(&node, buf));
+        run.category_name = text(&node, buf).to_string();
     }
     if let Ok(node) = child(&node, "platform") {
-        run.metadata_mut().set_platform_name(text(&node, buf));
+        run.metadata.set_platform_name(text(&node, buf));
     }
     if let Ok(node) = child(&node, "region") {
-        run.metadata_mut().set_region_name(text(&node, buf));
+        run.metadata.set_region_name(text(&node, buf));
     }
-    run.metadata_mut()
+    run.metadata
         .set_emulator_usage(text(&child(&node, "emulated")?, buf) == "true");
 
     let segments = child(&node, "segments")?;
@@ -130,7 +130,7 @@ pub fn parse<R: Read>(mut source: R) -> Result<Run> {
             segment.set_best_segment_time(time(&node, buf)?);
         }
 
-        run.push_segment(segment);
+        run.segments.push(segment);
     }
 
     Ok(run)

--- a/src/run/parser/llanfair_gered.rs
+++ b/src/run/parser/llanfair_gered.rs
@@ -128,7 +128,7 @@ pub fn parse<R: Read>(mut source: R) -> Result<Run> {
 
         if let Ok(node) = child(&node, "bestTime") {
             if let Ok(node) = child(&node, "milliseconds") {
-                segment.set_best_segment_time(time(&node, buf)?);
+                segment.best_segment_time = time(&node, buf)?;
             }
         }
 
@@ -137,7 +137,7 @@ pub fn parse<R: Read>(mut source: R) -> Result<Run> {
                 total_time += time_span(&node, buf)?;
             } else if let Ok("../bestTime") = attribute(&node, "reference") {
                 total_time += segment
-                    .best_segment_time()
+                    .best_segment_time
                     .real_time
                     .ok_or(Error::ElementNotFound)?;
             }
@@ -145,7 +145,7 @@ pub fn parse<R: Read>(mut source: R) -> Result<Run> {
         }
 
         if let Ok(image) = image(&node, &mut byte_buf, &mut byte_buf2, buf) {
-            segment.set_icon(image);
+            segment.icon = image.into();
         }
 
         run.segments.push(segment);

--- a/src/run/parser/llanfair_gered.rs
+++ b/src/run/parser/llanfair_gered.rs
@@ -110,12 +110,11 @@ pub fn parse<R: Read>(mut source: R) -> Result<Run> {
     let node = child(&node, "Run")?;
     let node = child(&node, "default")?;
 
-    run.set_game_name(text(&child(&node, "name")?, buf));
-    run.set_category_name(text(&child(&node, "subTitle")?, buf));
-    run.set_offset(
-        TimeSpan::zero() - time_span(&child(&node, "delayedStart")?, buf)?,
-    );
-    run.set_attempt_count(text(&child(&node, "numberOfAttempts")?, buf).parse()?);
+    run.game_name = text(&child(&node, "name")?, buf).to_string();
+    run.category_name = text(&child(&node, "subTitle")?, buf).to_string();
+    run.offset =
+        TimeSpan::zero() - time_span(&child(&node, "delayedStart")?, buf)?;
+    run.attempt_count = text(&child(&node, "numberOfAttempts")?, buf).parse()?;
 
     let segments = child(&node, "segments")?;
 
@@ -149,7 +148,7 @@ pub fn parse<R: Read>(mut source: R) -> Result<Run> {
             segment.set_icon(image);
         }
 
-        run.push_segment(segment);
+        run.segments.push(segment);
     }
 
     Ok(run)

--- a/src/run/parser/portal2_live_timer.rs
+++ b/src/run/parser/portal2_live_timer.rs
@@ -138,8 +138,8 @@ static CHAPTERS: [(&str, &[&str]); 9] = [
 pub fn parse<R: BufRead>(source: R) -> Result<Run> {
     let mut run = Run::new();
 
-    run.set_game_name("Portal 2");
-    run.set_category_name("Any%");
+    run.game_name = "Portal 2".to_string();
+    run.category_name = "Any%".to_string();
 
     let mut lines = source.lines().peekable();
     lines.next(); // Skip the header
@@ -164,7 +164,7 @@ pub fn parse<R: BufRead>(source: R) -> Result<Run> {
         let mut segment = Segment::new(chapter_name);
         segment.set_personal_best_split_time(time);
 
-        run.push_segment(segment);
+        run.segments.push(segment);
     }
 
     Ok(run)

--- a/src/run/parser/shit_split.rs
+++ b/src/run/parser/shit_split.rs
@@ -36,8 +36,8 @@ pub fn parse<R: BufRead>(source: R) -> Result<Run> {
     if !category_name.starts_with('#') {
         return Err(Error::ExpectedCategoryName);
     }
-    run.set_category_name(&category_name[1..]);
-    run.set_attempt_count(splits.next().ok_or(Error::ExpectedAttemptCount)?.parse()?);
+    run.category_name = category_name[1..].to_string();
+    run.attempt_count = splits.next().ok_or(Error::ExpectedAttemptCount)?.parse()?;
     let mut total_time = TimeSpan::zero();
     let mut next_line = lines.next();
     while let Some(line) = next_line {
@@ -53,7 +53,7 @@ pub fn parse<R: BufRead>(source: R) -> Result<Run> {
         while let Some(line) = next_line {
             let line = line?;
             if line.starts_with('*') {
-                run.push_segment(Segment::new(&line[1..]));
+                run.segments.push(Segment::new(&line[1..]));
                 has_acts = true;
                 next_line = lines.next();
             } else {
@@ -63,14 +63,14 @@ pub fn parse<R: BufRead>(source: R) -> Result<Run> {
         }
         let time = GameTime(Some(total_time)).into();
         if has_acts {
-            run.segments_mut()
+            run.segments
                 .last_mut()
                 .unwrap()
                 .set_personal_best_split_time(time);
         } else {
             let mut segment = Segment::new(world_name);
             segment.set_personal_best_split_time(time);
-            run.push_segment(segment);
+            run.segments.push(segment);
         }
     }
 

--- a/src/run/parser/splitterz.rs
+++ b/src/run/parser/splitterz.rs
@@ -44,8 +44,8 @@ pub fn parse<R: BufRead>(source: R, load_icons: bool) -> Result<Run> {
     let line = lines.next().ok_or(Error::Empty)??;
     let mut splits = line.split(',');
     // Title Stuff here, do later
-    run.set_category_name(unescape(splits.next().ok_or(Error::ExpectedCategoryName)?));
-    run.set_attempt_count(splits.next().ok_or(Error::ExpectedAttemptCount)?.parse()?);
+    run.category_name = unescape(splits.next().ok_or(Error::ExpectedCategoryName)?).to_string();
+    run.attempt_count = splits.next().ok_or(Error::ExpectedAttemptCount)?.parse()?;
 
     for line in lines {
         let line = line?;
@@ -77,7 +77,7 @@ pub fn parse<R: BufRead>(source: R, load_icons: bool) -> Result<Run> {
                 }
             }
 
-            run.push_segment(segment);
+            run.segments.push(segment);
         } else {
             break;
         }

--- a/src/run/parser/splitterz.rs
+++ b/src/run/parser/splitterz.rs
@@ -62,7 +62,7 @@ pub fn parse<R: BufRead>(source: R, load_icons: bool) -> Result<Run> {
 
             let time: TimeSpan = splits.next().ok_or(Error::ExpectedBestSegment)?.parse()?;
             if time != TimeSpan::zero() {
-                segment.set_best_segment_time(Time::new().with_real_time(Some(time)));
+                segment.best_segment_time = Time::new().with_real_time(Some(time));
             }
 
             if load_icons {
@@ -71,7 +71,7 @@ pub fn parse<R: BufRead>(source: R, load_icons: bool) -> Result<Run> {
                         if let Ok(image) =
                             Image::from_file(unescape(icon_path).as_ref(), &mut icon_buf)
                         {
-                            segment.set_icon(image);
+                            segment.icon = image;
                         }
                     }
                 }

--- a/src/run/parser/splitty.rs
+++ b/src/run/parser/splitty.rs
@@ -46,9 +46,9 @@ pub fn parse<R: Read>(source: R) -> Result<Run> {
 
     let splits: Splits = from_reader(source)?;
 
-    run.set_game_name(splits.run_name);
-    run.set_attempt_count(splits.run_count);
-    run.set_offset(TimeSpan::from_milliseconds(-splits.start_delay));
+    run.game_name = splits.run_name;
+    run.attempt_count = splits.run_count;
+    run.offset = TimeSpan::from_milliseconds(-splits.start_delay);
 
     let method = if splits.timer_type == 0 {
         TimingMethod::RealTime
@@ -61,7 +61,7 @@ pub fn parse<R: Read>(source: R) -> Result<Run> {
         segment.set_personal_best_split_time(parse_time(split.pb_split, method));
         segment.set_best_segment_time(parse_time(split.split_best, method));
 
-        run.push_segment(segment);
+        run.segments.push(segment);
     }
 
     Ok(run)

--- a/src/run/parser/splitty.rs
+++ b/src/run/parser/splitty.rs
@@ -59,7 +59,7 @@ pub fn parse<R: Read>(source: R) -> Result<Run> {
     for split in splits.splits {
         let mut segment = Segment::new(split.name);
         segment.set_personal_best_split_time(parse_time(split.pb_split, method));
-        segment.set_best_segment_time(parse_time(split.split_best, method));
+        segment.best_segment_time = parse_time(split.split_best, method);
 
         run.segments.push(segment);
     }

--- a/src/run/parser/time_split_tracker.rs
+++ b/src/run/parser/time_split_tracker.rs
@@ -74,7 +74,7 @@ pub fn parse<R: BufRead>(source: R, path_for_loading_other_files: Option<PathBuf
         let mut splits = line.split('\t');
         let mut segment = Segment::new(splits.next().ok_or(Error::ExpectedSplitName)?);
         let best_segment = parse_time_optional(splits.next().ok_or(Error::ExpectedBestSegment)?)?;
-        segment.set_best_segment_time(RealTime(best_segment).into());
+        segment.best_segment_time = RealTime(best_segment).into();
 
         let mut pb_time = Time::new();
         for comparison in &comparisons {
@@ -92,7 +92,7 @@ pub fn parse<R: BufRead>(source: R, path_for_loading_other_files: Option<PathBuf
             if !file.is_empty() {
                 let path = path.with_file_name(file);
                 if let Ok(image) = Image::from_file(path, &mut buf) {
-                    segment.set_icon(image);
+                    segment.icon = image;
                 }
             }
         }
@@ -162,15 +162,15 @@ fn parse_history(run: &mut Run, path: Option<PathBuf>) -> StdResult<(), ()> {
                 }
 
                 segment
-                    .segment_history_mut()
+                    .segment_history
                     .insert(attempt_id, segment_time);
                 if TimeSpan::option_op(
                     segment_time.real_time,
-                    segment.best_segment_time().real_time,
+                    segment.best_segment_time.real_time,
                     |a, b| a < b,
                 ).unwrap_or(false)
                 {
-                    segment.set_best_segment_time(segment_time);
+                    segment.best_segment_time = segment_time;
                 }
             }
 

--- a/src/run/parser/time_split_tracker.rs
+++ b/src/run/parser/time_split_tracker.rs
@@ -50,18 +50,18 @@ pub fn parse<R: BufRead>(source: R, path_for_loading_other_files: Option<PathBuf
 
     let line = lines.next().ok_or(Error::Empty)??;
     let mut splits = line.split('\t');
-    run.set_attempt_count(splits.next().ok_or(Error::ExpectedAttemptCount)?.parse()?);
-    run.set_offset(splits.next().ok_or(Error::ExpectedOffset)?.parse()?);
+    run.attempt_count = splits.next().ok_or(Error::ExpectedAttemptCount)?.parse()?;
+    run.offset = splits.next().ok_or(Error::ExpectedOffset)?.parse()?;
     if let (&Some(ref path), Some(file)) = (&path, splits.next()) {
         let path = path.with_file_name(file);
         if let Ok(image) = Image::from_file(path, &mut buf) {
-            run.set_game_icon(image);
+            run.game_icon = image;
         }
     }
 
     let line = lines.next().ok_or(Error::ExpectedTitleLine)??;
     let mut splits = line.split('\t');
-    run.set_category_name(splits.next().ok_or(Error::ExpectedCategoryName)?);
+    run.category_name = splits.next().ok_or(Error::ExpectedCategoryName)?.to_string();
     splits.next(); // Skip one element
     let comparisons = splits.collect::<Vec<_>>();
 
@@ -97,7 +97,7 @@ pub fn parse<R: BufRead>(source: R, path_for_loading_other_files: Option<PathBuf
             }
         }
 
-        run.push_segment(segment);
+        run.segments.push(segment);
     }
 
     parse_history(&mut run, path).ok();
@@ -152,7 +152,7 @@ fn parse_history(run: &mut Run, path: Option<PathBuf>) -> StdResult<(), ()> {
 
             let mut last_split = TimeSpan::zero();
             for (segment, current_split) in
-                run.segments_mut().iter_mut().zip(split_times.into_iter())
+                run.segments.iter_mut().zip(split_times.into_iter())
             {
 
                 let mut segment_time = Time::default();

--- a/src/run/parser/urn.rs
+++ b/src/run/parser/urn.rs
@@ -75,7 +75,7 @@ pub fn parse<R: Read>(source: R) -> Result<Run> {
                 segment.set_personal_best_split_time(parse_time(&time)?);
             }
             if let Some(best_segment) = split.best_segment {
-                segment.set_best_segment_time(parse_time(&best_segment)?);
+                segment.best_segment_time = parse_time(&best_segment)?;
             }
 
             if let Some(best_time) = split.best_time {
@@ -92,12 +92,12 @@ pub fn parse<R: Read>(source: R) -> Result<Run> {
                     // Insert a new run that skips to the current split
                     for already_inserted_segment in &mut run.segments {
                         already_inserted_segment
-                            .segment_history_mut()
+                            .segment_history
                             .insert(attempt_history_index, Time::default());
                     }
 
                     segment
-                        .segment_history_mut()
+                        .segment_history
                         .insert(attempt_history_index, best_split_time);
 
                     attempt_history_index += 1;

--- a/src/run/parser/urn.rs
+++ b/src/run/parser/urn.rs
@@ -53,13 +53,13 @@ pub fn parse<R: Read>(source: R) -> Result<Run> {
     let splits: Splits = from_reader(source)?;
 
     if let Some(title) = splits.title {
-        run.set_category_name(title);
+        run.category_name = title;
     }
     if let Some(attempt_count) = splits.attempt_count {
-        run.set_attempt_count(attempt_count);
+        run.attempt_count = attempt_count;
     }
     if let Some(start_delay) = splits.start_delay {
-        run.set_offset(-start_delay.parse()?);
+        run.offset = -start_delay.parse()?;
     }
 
     // Best Split Times can be used for the Segment History
@@ -90,7 +90,7 @@ pub fn parse<R: Read>(source: R) -> Result<Run> {
                     );
 
                     // Insert a new run that skips to the current split
-                    for already_inserted_segment in run.segments_mut() {
+                    for already_inserted_segment in &mut run.segments {
                         already_inserted_segment
                             .segment_history_mut()
                             .insert(attempt_history_index, Time::default());
@@ -104,7 +104,7 @@ pub fn parse<R: Read>(source: R) -> Result<Run> {
                 }
             }
 
-            run.push_segment(segment);
+            run.segments.push(segment);
         }
     }
 

--- a/src/run/parser/wsplit.rs
+++ b/src/run/parser/wsplit.rs
@@ -34,13 +34,13 @@ pub fn parse<R: BufRead>(source: R, load_icons: bool) -> Result<Run> {
         let line = line?;
         if !line.is_empty() {
             if line.starts_with("Title=") {
-                run.set_category_name(&line["Title=".len()..]);
+                run.category_name = line["Title=".len()..].to_string();
             } else if line.starts_with("Attempts=") {
-                run.set_attempt_count(line["Attempts=".len()..].parse()?);
+                run.attempt_count = line["Attempts=".len()..].parse()?;
             } else if line.starts_with("Offset=") {
                 let offset = &line["Offset=".len()..];
                 if !offset.is_empty() {
-                    run.set_offset(TimeSpan::from_milliseconds(-offset.parse::<f64>()?));
+                    run.offset = TimeSpan::from_milliseconds(-offset.parse::<f64>()?);
                 }
             } else if line.starts_with("Size=") {
                 // Ignore
@@ -91,7 +91,7 @@ pub fn parse<R: BufRead>(source: R, load_icons: bool) -> Result<Run> {
 
                 segment.set_personal_best_split_time(pb_time);
                 segment.set_best_segment_time(best_time);
-                run.push_segment(segment);
+                run.segments.push(segment);
             }
         }
     }
@@ -100,7 +100,7 @@ pub fn parse<R: BufRead>(source: R, load_icons: bool) -> Result<Run> {
         run.add_custom_comparison("Old Run");
     }
 
-    for (icon, segment) in icons_list.into_iter().zip(run.segments_mut().iter_mut()) {
+    for (icon, segment) in icons_list.into_iter().zip(run.segments.iter_mut()) {
         segment.set_icon(icon);
     }
 

--- a/src/run/parser/wsplit.rs
+++ b/src/run/parser/wsplit.rs
@@ -90,7 +90,7 @@ pub fn parse<R: BufRead>(source: R, load_icons: bool) -> Result<Run> {
                 }
 
                 segment.set_personal_best_split_time(pb_time);
-                segment.set_best_segment_time(best_time);
+                segment.best_segment_time = best_time;
                 run.segments.push(segment);
             }
         }
@@ -101,7 +101,7 @@ pub fn parse<R: BufRead>(source: R, load_icons: bool) -> Result<Run> {
     }
 
     for (icon, segment) in icons_list.into_iter().zip(run.segments.iter_mut()) {
-        segment.set_icon(icon);
+        segment.icon = icon;
     }
 
     Ok(run)

--- a/src/run/run.rs
+++ b/src/run/run.rs
@@ -258,7 +258,7 @@ impl Run {
     pub fn clear_history(&mut self) {
         self.attempt_history.clear();
         for segment in &mut self.segments {
-            segment.segment_history_mut().clear();
+            segment.segment_history.clear();
         }
     }
 
@@ -266,8 +266,8 @@ impl Run {
         self.clear_history();
         self.custom_comparisons.retain(|c| c == personal_best::NAME);
         for segment in &mut self.segments {
-            segment.comparisons_mut().clear();
-            segment.set_best_segment_time(Time::default());
+            segment.comparisons.clear();
+            segment.best_segment_time = Time::default();
         }
         self.attempt_count = 0;
         self.metadata.run_id.clear();
@@ -276,8 +276,8 @@ impl Run {
     fn fix_comparison_times_and_history(&mut self, method: TimingMethod) {
         // Remove negative Best Segment Times
         for segment in &mut self.segments {
-            if segment.best_segment_time_mut()[method].map_or(false, |t| t < TimeSpan::zero()) {
-                segment.best_segment_time_mut()[method] = None;
+            if segment.best_segment_time[method].map_or(false, |t| t < TimeSpan::zero()) {
+                segment.best_segment_time[method] = None;
             }
         }
 
@@ -296,10 +296,10 @@ impl Run {
                     if comparison == personal_best::NAME {
                         fix_history_from_null_best_segments(segment, method);
 
-                        if segment.best_segment_time()[method]
+                        if segment.best_segment_time[method]
                             .map_or(true, |t| t > current_segment)
                         {
-                            segment.best_segment_time_mut()[method] = Some(current_segment);
+                            segment.best_segment_time[method] = Some(current_segment);
                         }
 
                         fix_history_from_best_segment_times(segment, method);
@@ -316,7 +316,7 @@ impl Run {
         let max_index = self.max_attempt_history_index().unwrap_or(0) + 1;
         for run_index in min_index..max_index {
             for index in 0..self.len() {
-                if let Some(element) = self.segments[index].segment_history().get(run_index) {
+                if let Some(element) = self.segments[index].segment_history.get(run_index) {
                     if element.real_time.is_none() && element.game_time.is_none() {
                         cache.push(run_index);
                     } else {
@@ -336,7 +336,7 @@ impl Run {
         let mut history = Vec::new();
 
         for segment in &mut self.segments {
-            let segment_history = segment.segment_history_mut();
+            let segment_history = &mut segment.segment_history;
             history.clear();
             history.extend(segment_history.iter().filter_map(|&(_, t)| t[method]));
 
@@ -362,14 +362,14 @@ impl Run {
     fn remove_items_from_cache(&mut self, index: usize, cache: &mut Vec<i32>) {
         let ind = index - cache.len();
         for (index, segment) in cache.drain(..).zip(self.segments[ind..].iter_mut()) {
-            segment.segment_history_mut().remove(index);
+            segment.segment_history.remove(index);
         }
     }
 
     pub fn min_segment_history_index(&self) -> i32 {
         self.segments
             .iter()
-            .map(|s| s.segment_history().min_index())
+            .map(|s| s.segment_history.min_index())
             .min()
             .unwrap()
     }
@@ -385,7 +385,7 @@ impl Run {
                 let pb_time = segment.personal_best_split_time()[timing_method];
                 let time =
                     Time::new().with_timing_method(timing_method, pb_time.map(|p| p - prev_time));
-                segment.segment_history_mut().insert(index, time);
+                segment.segment_history.insert(index, time);
 
                 if let Some(time) = pb_time {
                     prev_time = time;
@@ -395,11 +395,11 @@ impl Run {
     }
 
     pub fn import_best_segment(&mut self, segment_index: usize) {
-        let best_segment_time = self.segments[segment_index].best_segment_time();
+        let best_segment_time = self.segments[segment_index].best_segment_time;
         if best_segment_time.real_time.is_some() || best_segment_time.game_time.is_some() {
             let index = self.min_segment_history_index() - 1;
             self.segments[segment_index]
-                .segment_history_mut()
+                .segment_history
                 .insert(index, best_segment_time);
         }
     }
@@ -413,9 +413,9 @@ impl Run {
         let index = self.attempt_history.last().unwrap().index();
 
         for segment in segments {
-            let split_time = segment.split_time();
+            let split_time = segment.split_time;
             let segment_time = Time::op(split_time, last_split_time, |a, b| a - b);
-            segment.segment_history_mut().insert(index, segment_time);
+            segment.segment_history.insert(index, segment_time);
             if let Some(time) = split_time.real_time {
                 last_split_time.real_time = Some(time);
             }
@@ -428,17 +428,17 @@ impl Run {
 
 fn fix_history_from_null_best_segments(segment: &mut Segment, method: TimingMethod) {
     // Only do anything if the Best Segment Time is gone for the Segment in question
-    if segment.best_segment_time()[method].is_none() {
+    if segment.best_segment_time[method].is_none() {
         // Keep only the skipped segments
         segment
-            .segment_history_mut()
+            .segment_history
             .retain(|&(_, time)| time[method].is_none());
     }
 }
 
 fn fix_history_from_best_segment_times(segment: &mut Segment, method: TimingMethod) {
-    if let Some(best_segment) = segment.best_segment_time()[method] {
-        for &mut (_, ref mut time) in segment.segment_history_mut() {
+    if let Some(best_segment) = segment.best_segment_time[method] {
+        for &mut (_, ref mut time) in &mut segment.segment_history {
             // Make sure no times in the history are lower than the Best Segment
             if let Some(ref mut time) = time[method] {
                 if *time < best_segment {

--- a/src/run/run.rs
+++ b/src/run/run.rs
@@ -8,17 +8,17 @@ use unicase;
 
 #[derive(Clone, Debug)]
 pub struct Run {
-    game_icon: Image,
-    game_name: String,
-    category_name: String,
-    offset: TimeSpan,
-    attempt_count: u32,
+    pub game_icon: Image,
+    pub game_name: String,
+    pub category_name: String,
+    pub offset: TimeSpan,
+    pub attempt_count: u32,
     attempt_history: Vec<Attempt>,
-    metadata: RunMetadata,
+    pub metadata: RunMetadata,
     has_changed: bool,
-    path: Option<PathBuf>,
-    segments: Vec<Segment>,
-    custom_comparisons: Vec<String>,
+    pub path: Option<PathBuf>,
+    pub segments: Vec<Segment>,
+    pub custom_comparisons: Vec<String>,
     comparison_generators: Vec<Box<ComparisonGenerator>>,
 }
 
@@ -43,122 +43,14 @@ impl Run {
         run
     }
 
-    #[inline]
-    pub fn game_name(&self) -> &str {
-        &self.game_name
-    }
-
-    #[inline]
-    pub fn set_game_name<S>(&mut self, name: S)
-    where
-        S: AsRef<str>,
-    {
-        self.game_name.clear();
-        self.game_name.push_str(name.as_ref());
-    }
-
-    #[inline]
-    pub fn game_icon(&self) -> &Image {
-        &self.game_icon
-    }
-
-    #[inline]
-    pub fn set_game_icon<D: Into<Image>>(&mut self, image: D) {
-        self.game_icon = image.into();
-    }
-
-    #[inline]
-    pub fn category_name(&self) -> &str {
-        &self.category_name
-    }
-
-    #[inline]
-    pub fn set_category_name<S>(&mut self, name: S)
-    where
-        S: AsRef<str>,
-    {
-        self.category_name.clear();
-        self.category_name.push_str(name.as_ref());
-    }
-
-    #[inline]
-    pub fn set_path(&mut self, path: Option<PathBuf>) {
-        self.path = path;
-    }
-
-    #[inline]
-    pub fn set_offset(&mut self, offset: TimeSpan) {
-        self.offset = offset;
-    }
-
-    #[inline]
-    pub fn attempt_count(&self) -> u32 {
-        self.attempt_count
-    }
-
-    #[inline]
-    pub fn set_attempt_count(&mut self, attempts: u32) {
-        self.attempt_count = attempts;
-    }
-
-    #[inline]
-    pub fn metadata(&self) -> &RunMetadata {
-        &self.metadata
-    }
-
-    #[inline]
-    pub fn metadata_mut(&mut self) -> &mut RunMetadata {
-        &mut self.metadata
-    }
-
-    #[inline]
-    pub fn offset(&self) -> TimeSpan {
-        self.offset
-    }
-
     pub fn start_next_run(&mut self) {
         self.attempt_count += 1;
         self.has_changed = true;
     }
 
     #[inline]
-    pub fn segments(&self) -> &[Segment] {
-        &self.segments
-    }
-
-    #[inline]
-    pub fn segments_mut(&mut self) -> &mut Vec<Segment> {
-        &mut self.segments
-    }
-
-    #[inline]
-    pub fn push_segment(&mut self, segment: Segment) {
-        self.segments.push(segment);
-    }
-
-    #[inline]
-    pub fn segment(&self, index: usize) -> &Segment {
-        &self.segments[index]
-    }
-
-    #[inline]
-    pub fn segment_mut(&mut self, index: usize) -> &mut Segment {
-        &mut self.segments[index]
-    }
-
-    #[inline]
     pub fn attempt_history(&self) -> &[Attempt] {
         &self.attempt_history
-    }
-
-    #[inline]
-    pub fn custom_comparisons(&self) -> &[String] {
-        &self.custom_comparisons
-    }
-
-    #[inline]
-    pub fn custom_comparisons_mut(&mut self) -> &mut Vec<String> {
-        &mut self.custom_comparisons
     }
 
     #[inline]
@@ -245,12 +137,12 @@ impl Run {
     }
 
     pub fn extended_name(&self, use_extended_category_name: bool) -> String {
-        let mut name = self.game_name().to_owned();
+        let mut name = self.game_name.clone();
 
         let category_name = if use_extended_category_name {
             self.extended_category_name(false, false, true)
         } else {
-            self.category_name().into()
+            Cow::Borrowed(self.category_name.as_str())
         };
 
         if !category_name.is_empty() {
@@ -443,7 +335,7 @@ impl Run {
     fn remove_duplicates(&mut self, method: TimingMethod) {
         let mut history = Vec::new();
 
-        for segment in self.segments_mut() {
+        for segment in &mut self.segments {
             let segment_history = segment.segment_history_mut();
             history.clear();
             history.extend(segment_history.iter().filter_map(|&(_, t)| t[method]));
@@ -469,7 +361,7 @@ impl Run {
 
     fn remove_items_from_cache(&mut self, index: usize, cache: &mut Vec<i32>) {
         let ind = index - cache.len();
-        for (index, segment) in cache.drain(..).zip(self.segments_mut()[ind..].iter_mut()) {
+        for (index, segment) in cache.drain(..).zip(self.segments[ind..].iter_mut()) {
             segment.segment_history_mut().remove(index);
         }
     }
@@ -488,7 +380,7 @@ impl Run {
             index -= 1;
             let mut prev_time = TimeSpan::zero();
 
-            for segment in self.segments_mut() {
+            for segment in &mut self.segments {
                 // Import the PB splits into the history
                 let pb_time = segment.personal_best_split_time()[timing_method];
                 let time =

--- a/src/run/run.rs
+++ b/src/run/run.rs
@@ -106,7 +106,7 @@ impl Run {
 
     #[inline]
     pub fn clear_run_id(&mut self) {
-        self.metadata.set_run_id(String::new());
+        self.metadata.run_id = String::new();
     }
 
     #[inline]
@@ -212,15 +212,15 @@ impl Run {
             }
 
             if show_region {
-                let region = self.metadata.region_name();
+                let region = &self.metadata.region_name;
                 if !region.is_empty() {
                     push(category_name.to_mut(), &[region]);
                 }
             }
 
             if show_platform {
-                let platform = self.metadata.platform_name();
-                let uses_emulator = self.metadata.uses_emulator();
+                let platform = &self.metadata.platform_name;
+                let uses_emulator = self.metadata.uses_emulator;
 
                 match (!platform.is_empty(), uses_emulator) {
                     (true, true) => push(category_name.to_mut(), &[platform, " Emulator"]),
@@ -270,7 +270,7 @@ impl Run {
             segment.set_best_segment_time(Time::default());
         }
         self.attempt_count = 0;
-        self.metadata.set_run_id("");
+        self.metadata.run_id.clear();
     }
 
     fn fix_comparison_times_and_history(&mut self, method: TimingMethod) {

--- a/src/run/run_metadata.rs
+++ b/src/run/run_metadata.rs
@@ -2,10 +2,10 @@ use ordermap::{Iter, OrderMap};
 
 #[derive(Default, Clone, Debug)]
 pub struct RunMetadata {
-    run_id: String,
-    platform_name: String,
-    uses_emulator: bool,
-    region_name: String,
+    pub run_id: String,
+    pub platform_name: String,
+    pub uses_emulator: bool,
+    pub region_name: String,
     variables: OrderMap<String, String>,
 }
 
@@ -13,58 +13,6 @@ impl RunMetadata {
     #[inline]
     pub fn new() -> Self {
         Default::default()
-    }
-
-    #[inline]
-    pub fn run_id(&self) -> &str {
-        &self.run_id
-    }
-
-    #[inline]
-    pub fn set_run_id<S>(&mut self, id: S)
-    where
-        S: AsRef<str>,
-    {
-        self.run_id.clear();
-        self.run_id.push_str(id.as_ref());
-    }
-
-    #[inline]
-    pub fn platform_name(&self) -> &str {
-        &self.platform_name
-    }
-
-    #[inline]
-    pub fn set_platform_name<S>(&mut self, name: S)
-    where
-        S: AsRef<str>,
-    {
-        self.platform_name.clear();
-        self.platform_name.push_str(name.as_ref());
-    }
-
-    #[inline]
-    pub fn uses_emulator(&self) -> bool {
-        self.uses_emulator
-    }
-
-    #[inline]
-    pub fn set_emulator_usage(&mut self, uses_emulator: bool) {
-        self.uses_emulator = uses_emulator;
-    }
-
-    #[inline]
-    pub fn region_name(&self) -> &str {
-        &self.region_name
-    }
-
-    #[inline]
-    pub fn set_region_name<S>(&mut self, region_name: S)
-    where
-        S: AsRef<str>,
-    {
-        self.region_name.clear();
-        self.region_name.push_str(region_name.as_ref());
     }
 
     pub fn add_variable<N, V>(&mut self, name: N, value: V)

--- a/src/run/saver/livesplit.rs
+++ b/src/run/saver/livesplit.rs
@@ -85,14 +85,14 @@ pub fn save<W: Write>(run: &Run, mut writer: W) -> Result<()> {
     let metadata = doc.create_element("Metadata");
 
     let run_element = doc.create_element("Run");
-    run_element.set_attribute_value("id", run.metadata.run_id());
+    run_element.set_attribute_value("id", &run.metadata.run_id);
     metadata.append_child(run_element);
 
-    let platform = to_element(doc, "Platform", run.metadata.platform_name());
-    platform.set_attribute_value("usesEmulator", fmt_bool(run.metadata.uses_emulator()));
+    let platform = to_element(doc, "Platform", &run.metadata.platform_name);
+    platform.set_attribute_value("usesEmulator", fmt_bool(run.metadata.uses_emulator));
     metadata.append_child(platform);
 
-    add_element(doc, &metadata, "Region", run.metadata.region_name());
+    add_element(doc, &metadata, "Region", &run.metadata.region_name);
 
     let variables = doc.create_element("Variables");
     for (name, value) in run.metadata.variables() {

--- a/src/run/saver/livesplit.rs
+++ b/src/run/saver/livesplit.rs
@@ -141,8 +141,8 @@ pub fn save<W: Write>(run: &Run, mut writer: W) -> Result<()> {
     for segment in &run.segments {
         let segment_element = doc.create_element("Segment");
 
-        add_element(doc, &segment_element, "Name", segment.name());
-        add_element(doc, &segment_element, "Icon", &fmt_image(segment.icon()));
+        add_element(doc, &segment_element, "Name", &segment.name);
+        add_element(doc, &segment_element, "Icon", &fmt_image(&segment.icon));
 
         let split_times = doc.create_element("SplitTimes");
         for comparison in &run.custom_comparisons {
@@ -152,10 +152,10 @@ pub fn save<W: Write>(run: &Run, mut writer: W) -> Result<()> {
         }
         segment_element.append_child(split_times);
 
-        segment_element.append_child(time(doc, "BestSegmentTime", segment.best_segment_time()));
+        segment_element.append_child(time(doc, "BestSegmentTime", segment.best_segment_time));
 
         let history = doc.create_element("SegmentHistory");
-        for &(index, history_time) in segment.segment_history() {
+        for &(index, history_time) in &segment.segment_history {
             let element = time(doc, "Time", history_time);
             element.set_attribute_value("id", &index.to_string());
             history.append_child(element);

--- a/src/run/saver/livesplit.rs
+++ b/src/run/saver/livesplit.rs
@@ -78,24 +78,24 @@ pub fn save<W: Write>(run: &Run, mut writer: W) -> Result<()> {
     parent.set_attribute_value("version", "1.7.0");
     doc.root().append_child(parent);
 
-    add_element(doc, &parent, "GameIcon", &fmt_image(run.game_icon()));
-    add_element(doc, &parent, "GameName", run.game_name());
-    add_element(doc, &parent, "CategoryName", run.category_name());
+    add_element(doc, &parent, "GameIcon", &fmt_image(&run.game_icon));
+    add_element(doc, &parent, "GameName", &run.game_name);
+    add_element(doc, &parent, "CategoryName", &run.category_name);
 
     let metadata = doc.create_element("Metadata");
 
     let run_element = doc.create_element("Run");
-    run_element.set_attribute_value("id", run.metadata().run_id());
+    run_element.set_attribute_value("id", run.metadata.run_id());
     metadata.append_child(run_element);
 
-    let platform = to_element(doc, "Platform", run.metadata().platform_name());
-    platform.set_attribute_value("usesEmulator", fmt_bool(run.metadata().uses_emulator()));
+    let platform = to_element(doc, "Platform", run.metadata.platform_name());
+    platform.set_attribute_value("usesEmulator", fmt_bool(run.metadata.uses_emulator()));
     metadata.append_child(platform);
 
-    add_element(doc, &metadata, "Region", run.metadata().region_name());
+    add_element(doc, &metadata, "Region", run.metadata.region_name());
 
     let variables = doc.create_element("Variables");
-    for (name, value) in run.metadata().variables() {
+    for (name, value) in run.metadata.variables() {
         let variable = to_element(doc, "Variable", value);
         variable.set_attribute_value("name", name);
         variables.append_child(variable);
@@ -103,12 +103,12 @@ pub fn save<W: Write>(run: &Run, mut writer: W) -> Result<()> {
     metadata.append_child(variables);
     parent.append_child(metadata);
 
-    add_element(doc, &parent, "Offset", &time_span(run.offset()));
+    add_element(doc, &parent, "Offset", &time_span(run.offset));
     add_element(
         doc,
         &parent,
         "AttemptCount",
-        &run.attempt_count().to_string(),
+        &run.attempt_count.to_string(),
     );
 
     let attempt_history = doc.create_element("AttemptHistory");
@@ -138,14 +138,14 @@ pub fn save<W: Write>(run: &Run, mut writer: W) -> Result<()> {
     parent.append_child(attempt_history);
 
     let segments_element = doc.create_element("Segments");
-    for segment in run.segments() {
+    for segment in &run.segments {
         let segment_element = doc.create_element("Segment");
 
         add_element(doc, &segment_element, "Name", segment.name());
         add_element(doc, &segment_element, "Icon", &fmt_image(segment.icon()));
 
         let split_times = doc.create_element("SplitTimes");
-        for comparison in run.custom_comparisons() {
+        for comparison in &run.custom_comparisons {
             let split_time = time(doc, "SplitTime", segment.comparison(comparison));
             split_time.set_attribute_value("name", comparison);
             split_times.append_child(split_time);

--- a/src/run/segment.rs
+++ b/src/run/segment.rs
@@ -4,12 +4,12 @@ use comparison::personal_best;
 
 #[derive(Clone, Default, Debug)]
 pub struct Segment {
-    name: String,
-    icon: Image,
-    best_segment_time: Time,
-    split_time: Time,
-    segment_history: SegmentHistory,
-    comparisons: HashMap<String, Time>,
+    pub name: String,
+    pub icon: Image,
+    pub best_segment_time: Time,
+    pub split_time: Time,
+    pub segment_history: SegmentHistory,
+    pub comparisons: HashMap<String, Time>,
 }
 
 impl Segment {
@@ -21,35 +21,6 @@ impl Segment {
             name: name.into(),
             ..Default::default()
         }
-    }
-
-    #[inline]
-    pub fn name(&self) -> &str {
-        &self.name
-    }
-
-    #[inline]
-    pub fn set_name<S>(&mut self, name: S)
-    where
-        S: AsRef<str>,
-    {
-        self.name.clear();
-        self.name.push_str(name.as_ref());
-    }
-
-    #[inline]
-    pub fn icon(&self) -> &Image {
-        &self.icon
-    }
-
-    #[inline]
-    pub fn set_icon<D: Into<Image>>(&mut self, image: D) {
-        self.icon = image.into();
-    }
-
-    #[inline]
-    pub fn comparisons_mut(&mut self) -> &mut HashMap<String, Time> {
-        &mut self.comparisons
     }
 
     #[inline]
@@ -97,47 +68,7 @@ impl Segment {
     }
 
     #[inline]
-    pub fn best_segment_time(&self) -> Time {
-        self.best_segment_time
-    }
-
-    #[inline]
-    pub fn best_segment_time_mut(&mut self) -> &mut Time {
-        &mut self.best_segment_time
-    }
-
-    #[inline]
-    pub fn set_best_segment_time(&mut self, time: Time) {
-        self.best_segment_time = time;
-    }
-
-    #[inline]
-    pub fn split_time(&self) -> Time {
-        self.split_time
-    }
-
-    #[inline]
-    pub fn split_time_mut(&mut self) -> &mut Time {
-        &mut self.split_time
-    }
-
-    #[inline]
-    pub fn set_split_time(&mut self, time: Time) {
-        self.split_time = time;
-    }
-
-    #[inline]
     pub fn clear_split_time(&mut self) {
-        self.set_split_time(Default::default());
-    }
-
-    #[inline]
-    pub fn segment_history(&self) -> &SegmentHistory {
-        &self.segment_history
-    }
-
-    #[inline]
-    pub fn segment_history_mut(&mut self) -> &mut SegmentHistory {
-        &mut self.segment_history
+        self.split_time = Default::default();
     }
 }


### PR DESCRIPTION
A few structs (`Run`, `RunMetadata`, `Segment`) used a lot of getter's and setter's which didn't add much, if anything at all, to just having that field be public. Those kinds empty getters and setters are considered bad practice as they clutter up the api unnecessarily, and this pull request adresses that.

The main files to look at here are `src/run/run.rs`, `src/run/segment.rs`, and `src/run/run_metadata.rs`, as they contain the api-changing sections of code. The rest of the files are mainly cascading the api changes to the rest of this crate. The philosophy I took for what to change to public fields was based on if the field had both a getter and a setter/mut function and both of these functions boiled down to a `&self.field` and `self.field = input` (or `&mut self.field`).

If you have any questions about the changes, please let me know.