### PR TITLE
Python 3 data validation for Run.parse_file

### DIFF
--- a/capi/bind_gen/src/python.rs
+++ b/capi/bind_gen/src/python.rs
@@ -289,7 +289,11 @@ class {class}({base_class}):
                 r#"
     @staticmethod
     def parse_file(file):
-        bytes = bytearray(file.read())
+        data = file.read()
+        if sys.version_info[0] > 2:
+            if isinstance(data, str):
+                raise TypeError("File must be opened in binary mode!")
+        bytes = bytearray(data)
         bufferType = c_byte * len(bytes)
         buffer = bufferType(*bytes)
         return Run.parse(buffer, len(bytes))"#


### PR DESCRIPTION
In Python 3 we need bytes, not str, from the file read in order to parse the run. So we check to make sure we got the right data type.  The wrong type means the file was opened in the wrong mode.

This patch makes us throw a meaningful exception, instead of something inscrutable.