### PR TITLE
Remove Timer.{replace, set}_run()

### DIFF
--- a/capi/src/timer.rs
+++ b/capi/src/timer.rs
@@ -1,6 +1,6 @@
 use livesplit_core::{Run, TimeSpan, Timer, TimerPhase, TimingMethod};
 use super::{acc, acc_mut, alloc, output_str, output_time_span, own, own_drop};
-use run::{NullableOwnedRun, OwnedRun};
+use run::OwnedRun;
 use libc::c_char;
 use shared_timer::OwnedSharedTimer;
 use std::ptr;
@@ -21,31 +21,6 @@ pub unsafe extern "C" fn Timer_into_shared(this: OwnedTimer) -> OwnedSharedTimer
 #[no_mangle]
 pub unsafe extern "C" fn Timer_drop(this: OwnedTimer) {
     own_drop(this);
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn Timer_replace_run(
-    this: *mut Timer,
-    run: *mut Run,
-    update_splits: bool,
-) -> bool {
-    // This working correctly relies on panic = "abort",
-    // as a panic would leave the run in an uninitialized state.
-    let result = acc_mut(this).replace_run(ptr::read(run), update_splits);
-    let was_successful = result.is_ok();
-    let result = match result {
-        Ok(r) | Err(r) => r,
-    };
-    ptr::write(run, result);
-    was_successful
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn Timer_set_run(this: *mut Timer, run: OwnedRun) -> NullableOwnedRun {
-    acc_mut(this)
-        .set_run(own(run))
-        .err()
-        .map_or_else(ptr::null_mut, alloc)
 }
 
 #[no_mangle]

--- a/src/time/timer.rs
+++ b/src/time/timer.rs
@@ -3,7 +3,6 @@ use TimerPhase::*;
 use comparison::personal_best;
 use parking_lot::RwLock;
 use std::sync::Arc;
-use std::mem;
 
 #[derive(Debug, Clone)]
 pub struct Timer {
@@ -63,23 +62,6 @@ impl Timer {
 
     pub fn into_shared(self) -> SharedTimer {
         Arc::new(RwLock::new(self))
-    }
-
-    pub fn replace_run(&mut self, run: Run, update_splits: bool) -> Result<Run, Run> {
-        if run.is_empty() {
-            return Err(run);
-        }
-
-        self.reset(update_splits);
-        if !run.comparisons().any(|c| c == self.current_comparison) {
-            self.current_comparison = personal_best::NAME.to_string();
-        }
-
-        Ok(mem::replace(&mut self.run, run))
-    }
-
-    pub fn set_run(&mut self, run: Run) -> Result<(), Run> {
-        self.replace_run(run, false).map(|_| ())
     }
 
     #[inline]


### PR DESCRIPTION
I'm finding it very hard to think of a situation where this is actually
useful, safe for trying to save an allocation, but even then the
allocation is quite small and it is usually better to just create a new
Timer.