### PR TITLE
Change Timer.current_split_index from isize to Option<usize>

### DIFF
--- a/src/analysis/current_pace.rs
+++ b/src/analysis/current_pace.rs
@@ -9,7 +9,7 @@ pub fn calculate(timer: &Timer, comparison: &str) -> Option<TimeSpan> {
         TimerPhase::Running | TimerPhase::Paused => {
             let mut delta = analysis::last_delta(
                 timer.run(),
-                timer.current_split_index() as usize,
+                timer.current_split_index().unwrap(),
                 comparison,
                 timing_method,
             ).unwrap_or_default();

--- a/src/analysis/delta.rs
+++ b/src/analysis/delta.rs
@@ -11,7 +11,7 @@ pub fn calculate(timer: &Timer, comparison: &str) -> (Option<TimeSpan>, bool) {
         TimerPhase::Running | TimerPhase::Paused => {
             let mut delta = analysis::last_delta(
                 timer.run(),
-                timer.current_split_index() as usize,
+                timer.current_split_index().unwrap(),
                 comparison,
                 timing_method,
             );

--- a/src/analysis/possible_time_save.rs
+++ b/src/analysis/possible_time_save.rs
@@ -31,7 +31,7 @@ pub fn calculate(
         |c, b| c - b - prev_time,
     );
 
-    if live && segment_index == timer.current_split_index() as usize {
+    if live && timer.current_split_index() == Some(segment_index) {
         let segment_delta = analysis::live_segment_delta(timer, segment_index, comparison, method);
         if let (Some(segment_delta), Some(time)) = (segment_delta, time.as_mut()) {
             let segment_delta = TimeSpan::zero() - segment_delta;

--- a/src/analysis/state_helper.rs
+++ b/src/analysis/state_helper.rs
@@ -161,7 +161,7 @@ pub fn check_live_delta(
             .unwrap()
             .comparison_timing_method(comparison, method);
         let current_time = timer.current_time()[method];
-        let split_index = timer.current_split_index() as usize;
+        let split_index = timer.current_split_index().unwrap();
         let current_segment = live_segment_time(timer, split_index, method);
         let best_segment = timer.run().segment(split_index).best_segment_time()[method];
         let best_segment_delta =

--- a/src/component/delta.rs
+++ b/src/component/delta.rs
@@ -96,14 +96,14 @@ impl Component {
 
         let mut index = timer.current_split_index();
         if !use_live_delta {
-            index -= 1;
+            index = index.and_then(|i| i.checked_sub(1));
         }
 
-        let semantic_color = if index >= 0 {
+        let semantic_color = if index.is_some() {
             state_helper::split_color(
                 timer,
                 delta,
-                index as usize,
+                index.unwrap(),
                 true,
                 false,
                 comparison,

--- a/src/component/detailed_timer.rs
+++ b/src/component/detailed_timer.rs
@@ -3,7 +3,6 @@ use super::timer;
 use time::formatter::{timer as formatter, Accuracy, DigitsFormat, Short, TimeFormatter, DASH};
 use time::formatter::none_wrapper::DashWrapper;
 use comparison::{self, best_segments, none};
-use std::cmp::max;
 use serde_json::{to_writer, Result};
 use std::io::Write;
 use std::borrow::Cow;
@@ -113,7 +112,7 @@ impl Component {
         let last_split_index = if current_phase == TimerPhase::Ended {
             timer.run().len() - 1
         } else {
-            max(0, timer.current_split_index()) as usize
+            timer.current_split_index().unwrap_or(0)
         };
 
         let (comparison1, comparison2) = if current_phase != TimerPhase::NotRunning {
@@ -347,7 +346,7 @@ fn calculate_comparison_time(
             .run()
             .segment(0)
             .comparison_timing_method(comparison, timing_method)
-    } else if timer.current_split_index() > 0 {
+    } else if timer.current_split_index() > Some(0) {
         TimeSpan::option_sub(
             timer
                 .run()

--- a/src/component/graph.rs
+++ b/src/component/graph.rs
@@ -524,7 +524,7 @@ impl Component {
                     .unwrap_or_else(TimeSpan::zero);
             } else {
                 let timing_method = timer.current_timing_method();
-                for segment in timer.run().segments()[..timer.current_split_index() as usize]
+                for segment in timer.run().segments()[..timer.current_split_index().unwrap()]
                     .iter()
                     .rev()
                 {

--- a/src/component/possible_time_save.rs
+++ b/src/component/possible_time_save.rs
@@ -3,7 +3,6 @@ use analysis::possible_time_save;
 use settings::{Field, Gradient, SettingsDescription, Value};
 use serde_json::{to_writer, Result};
 use std::borrow::Cow;
-use std::cmp::max;
 use std::fmt::Write as FmtWrite;
 use std::io::Write;
 use time::formatter::{Accuracy, PossibleTimeSave, TimeFormatter};
@@ -102,11 +101,11 @@ impl Component {
         let time = if self.settings.total_possible_time_save {
             Some(possible_time_save::calculate_total(
                 timer,
-                max(0, segment_index) as usize,
+                segment_index.unwrap_or(0),
                 comparison,
             ))
         } else if current_phase == TimerPhase::Running || current_phase == TimerPhase::Paused {
-            possible_time_save::calculate(timer, segment_index as usize, comparison, false)
+            possible_time_save::calculate(timer, segment_index.unwrap(), comparison, false)
         } else {
             None
         };

--- a/src/component/previous_segment.rs
+++ b/src/component/previous_segment.rs
@@ -104,8 +104,8 @@ impl Component {
 
         let phase = timer.current_phase();
         let method = timer.current_timing_method();
-        let split_index = timer.current_split_index() as usize;
         let semantic_color = if phase != TimerPhase::NotRunning {
+            let split_index = timer.current_split_index().unwrap();
             if (phase == TimerPhase::Running || phase == TimerPhase::Paused) &&
                 analysis::check_live_delta(timer, false, comparison, method).is_some()
             {

--- a/src/component/timer.rs
+++ b/src/component/timer.rs
@@ -97,7 +97,7 @@ impl Component {
                     split_color(
                         timer,
                         Some(time - pb_split_time),
-                        timer.current_split_index() as usize,
+                        timer.current_split_index().unwrap(),
                         true,
                         false,
                         current_comparison,

--- a/src/run/run.rs
+++ b/src/run/run.rs
@@ -511,12 +511,12 @@ impl Run {
         }
     }
 
-    pub fn update_segment_history(&mut self, current_split_index: isize) {
+    pub fn update_segment_history(&mut self, current_split_index: usize) {
         let mut last_split_time = Time::zero();
 
         let segments = self.segments
             .iter_mut()
-            .take(max(0, current_split_index) as usize);
+            .take(current_split_index);
         let index = self.attempt_history.last().unwrap().index();
 
         for segment in segments {

--- a/src/time/timer.rs
+++ b/src/time/timer.rs
@@ -9,7 +9,7 @@ use std::mem;
 pub struct Timer {
     run: Run,
     phase: TimerPhase,
-    current_split_index: isize,
+    current_split_index: Option<usize>,
     current_timing_method: TimingMethod,
     current_comparison: String,
     attempt_started: Option<AtomicDateTime>,
@@ -46,7 +46,7 @@ impl Timer {
         Ok(Timer {
             run: run,
             phase: NotRunning,
-            current_split_index: -1,
+            current_split_index: None,
             current_timing_method: TimingMethod::RealTime,
             current_comparison: personal_best::NAME.into(),
             attempt_started: None,
@@ -138,32 +138,26 @@ impl Timer {
     }
 
     pub fn current_split(&self) -> Option<&Segment> {
-        if self.current_split_index >= 0 {
-            self.run.segments().get(self.current_split_index as usize)
-        } else {
-            None
-        }
+        self.current_split_index.and_then(|i| {
+            self.run.segments().get(i)
+        })
     }
 
     fn current_split_mut(&mut self) -> Option<&mut Segment> {
-        if self.current_split_index >= 0 {
-            self.run
-                .segments_mut()
-                .get_mut(self.current_split_index as usize)
-        } else {
-            None
-        }
+        self.current_split_index.and_then(move |i| {
+            self.run.segments_mut().get_mut(i)
+        })
     }
 
     #[inline]
-    pub fn current_split_index(&self) -> isize {
+    pub fn current_split_index(&self) -> Option<usize> {
         self.current_split_index
     }
 
     pub fn start(&mut self) {
         if self.phase == NotRunning {
             self.phase = Running;
-            self.current_split_index = 0;
+            self.current_split_index = Some(0);
             self.attempt_started = Some(AtomicDateTime::now());
             self.start_time = TimeStamp::now();
             self.start_time_with_offset = self.start_time - self.run.offset();
@@ -186,8 +180,8 @@ impl Timer {
             self.current_split_mut()
                 .unwrap()
                 .set_split_time(current_time);
-            self.current_split_index += 1;
-            if self.run.len() as isize == self.current_split_index {
+            *self.current_split_index.as_mut().unwrap() += 1;
+            if Some(self.run.len()) == self.current_split_index {
                 self.phase = Ended;
                 self.attempt_ended = Some(AtomicDateTime::now());
             }
@@ -207,10 +201,10 @@ impl Timer {
 
     pub fn skip_split(&mut self) {
         if (self.phase == Running || self.phase == Paused) &&
-            self.current_split_index < self.run.len() as isize - 1
+            self.current_split_index < self.run.len().checked_sub(1)
         {
             self.current_split_mut().unwrap().clear_split_time();
-            self.current_split_index += 1;
+            self.current_split_index = self.current_split_index.map(|i| i+1);
             self.run.mark_as_changed();
 
             // TODO OnSkipSplit
@@ -218,11 +212,11 @@ impl Timer {
     }
 
     pub fn undo_split(&mut self) {
-        if self.phase != NotRunning && self.current_split_index > 0 {
+        if self.phase != NotRunning && self.current_split_index > Some(0) {
             if self.phase == Ended {
                 self.phase = Running;
             }
-            self.current_split_index -= 1;
+            self.current_split_index = self.current_split_index.map(|i| i-1);
             self.current_split_mut().unwrap().clear_split_time();
             self.run.mark_as_changed();
 
@@ -253,7 +247,7 @@ impl Timer {
 
     fn reset_splits(&mut self) {
         self.phase = NotRunning;
-        self.current_split_index = -1;
+        self.current_split_index = None;
 
         // Reset Splits
         for segment in self.run.segments_mut() {
@@ -489,7 +483,10 @@ impl Timer {
     }
 
     fn update_segment_history(&mut self) {
-        self.run.update_segment_history(self.current_split_index);
+        match self.current_split_index {
+            Some(i) => self.run.update_segment_history(i),
+            None => {},
+        }
     }
 
     fn set_run_as_pb(&mut self) {


### PR DESCRIPTION
It is the more rustic way and surprisingly doesn't effect the C api as far as I can tell. Also any panics from the unwraps (which should only be in places where there was some prior check of `TimerPhase::Running` or otherwise) would let us know of some logic error instead of just silently casting a `-1` isize to usize.