### PR TITLE
Introduce catch blocks to clean up the code

### DIFF
--- a/src/analysis/current_pace.rs
+++ b/src/analysis/current_pace.rs
@@ -14,18 +14,18 @@ pub fn calculate(timer: &Timer, comparison: &str) -> Option<TimeSpan> {
                 timing_method,
             ).unwrap_or_default();
 
-            let live_delta = TimeSpan::option_sub(
-                timer.current_time()[timing_method],
-                timer.current_split().unwrap().comparison(comparison)[timing_method],
-            );
+            catch! {
+                let live_delta = timer.current_time()[timing_method]?
+                    - timer.current_split().unwrap().comparison(comparison)[timing_method]?;
 
-            if let Some(live_delta) = live_delta {
                 if live_delta > delta {
                     delta = live_delta;
                 }
-            }
+            };
 
-            last_segment.comparison(comparison)[timing_method].map(|c| delta + c)
+            catch! {
+                last_segment.comparison(comparison)[timing_method]? + delta
+            }
         }
         TimerPhase::Ended => last_segment.split_time()[timing_method],
         TimerPhase::NotRunning => last_segment.comparison(comparison)[timing_method],

--- a/src/analysis/delta.rs
+++ b/src/analysis/delta.rs
@@ -16,24 +16,22 @@ pub fn calculate(timer: &Timer, comparison: &str) -> (Option<TimeSpan>, bool) {
                 timing_method,
             );
 
-            let live_delta = TimeSpan::option_sub(
-                timer.current_time()[timing_method],
-                timer.current_split().unwrap().comparison(comparison)[timing_method],
-            );
+            catch! {
+                let live_delta = timer.current_time()[timing_method]?
+                    - timer.current_split().unwrap().comparison(comparison)[timing_method]?;
 
-            if let Some(live_delta) = live_delta {
                 if live_delta > delta.unwrap_or_default() {
                     delta = Some(live_delta);
                     use_live_delta = true;
                 }
-            }
+            };
 
             delta
         }
-        TimerPhase::Ended => TimeSpan::option_sub(
-            last_segment.split_time()[timing_method],
-            last_segment.comparison(comparison)[timing_method],
-        ),
+        TimerPhase::Ended => catch! {
+            last_segment.split_time()[timing_method]?
+                - last_segment.comparison(comparison)[timing_method]?
+        },
         TimerPhase::NotRunning => None,
     };
 

--- a/src/comparison/latest_run.rs
+++ b/src/comparison/latest_run.rs
@@ -20,7 +20,7 @@ fn generate(segments: &mut [Segment], method: TimingMethod) {
         let mut remaining_segments = segments.iter_mut();
 
         let mut total_time = TimeSpan::zero();
-        while let Some(segment) = remaining_segments.next() {
+        for segment in remaining_segments.by_ref() {
             let segment_time = segment.segment_history().get(attempt_id).map(|t| t[method]);
 
             let split_time = match segment_time {

--- a/src/comparison/mod.rs
+++ b/src/comparison/mod.rs
@@ -73,7 +73,6 @@ pub fn or_current<'a>(comparison: Option<&'a str>, timer: &'a Timer) -> &'a str 
 }
 
 pub fn resolve<'a>(comparison: &Option<String>, timer: &'a Timer) -> Option<&'a str> {
-    comparison
-        .as_ref()
-        .and_then(|c| timer.run().comparisons().find(|&rc| c == rc))
+    let comparison = comparison.as_ref()?;
+    timer.run().comparisons().find(|&rc| comparison == rc)
 }

--- a/src/component/detailed_timer.rs
+++ b/src/component/detailed_timer.rs
@@ -347,15 +347,15 @@ fn calculate_comparison_time(
             .segment(0)
             .comparison_timing_method(comparison, timing_method)
     } else if timer.current_split_index() > Some(0) {
-        TimeSpan::option_sub(
+        Some(
             timer
                 .run()
                 .segment(last_split_index)
-                .comparison_timing_method(comparison, timing_method),
-            timer
-                .run()
-                .segment(last_split_index - 1)
-                .comparison_timing_method(comparison, timing_method),
+                .comparison_timing_method(comparison, timing_method)?
+                - timer
+                    .run()
+                    .segment(last_split_index - 1)
+                    .comparison_timing_method(comparison, timing_method)?,
         )
     } else {
         None
@@ -376,6 +376,6 @@ fn calculate_segment_time(
     if timer.current_phase() == TimerPhase::NotRunning {
         Some(timer.run().offset())
     } else {
-        TimeSpan::option_sub(timer.current_time()[timing_method], last_split)
+        Some(timer.current_time()[timing_method]? - last_split?)
     }
 }

--- a/src/component/graph.rs
+++ b/src/component/graph.rs
@@ -541,17 +541,18 @@ impl Component {
     fn calculate_deltas(&self, timer: &Timer, comparison: &str, draw_info: &mut DrawInfo) {
         let timing_method = timer.current_timing_method();
         for segment in timer.run().segments() {
-            let time = TimeSpan::option_sub(
-                segment.split_time()[timing_method],
-                segment.comparison(comparison)[timing_method],
-            );
-            if let Some(time) = time {
+            let time = catch! {
+                let time = segment.split_time()[timing_method]?
+                    - segment.comparison(comparison)[timing_method]?;
+
                 if time > draw_info.max_delta {
                     draw_info.max_delta = time;
                 } else if time < draw_info.min_delta {
                     draw_info.min_delta = time;
                 }
-            }
+
+                time
+            };
             draw_info.deltas.push(time);
         }
     }

--- a/src/component/splits.rs
+++ b/src/component/splits.rs
@@ -1,7 +1,7 @@
 use std::cmp::{max, min};
 use std::io::Write;
 use serde_json::{to_writer, Result};
-use {analysis, GeneralLayoutSettings, TimeSpan, Timer};
+use {analysis, GeneralLayoutSettings, Timer};
 use analysis::split_color;
 use time::formatter::{Delta, Regular, TimeFormatter};
 use time::formatter::none_wrapper::{DashWrapper, EmptyWrapper};
@@ -171,7 +171,7 @@ impl Component {
                     let comparison_time = segment.comparison(comparison)[method];
 
                     let (time, delta, semantic_color) = if current_split > Some(i) {
-                        let delta = TimeSpan::option_sub(split, comparison_time);
+                        let delta = catch! { split? - comparison_time? };
                         (
                             split,
                             delta,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,12 @@ pub extern crate ordermap;
 pub extern crate palette;
 pub extern crate parking_lot;
 
+macro_rules! catch {
+    ($($code:tt)*) => {
+        (|| { Some({ $($code)* }) })()
+    }
+}
+
 mod hotkey_config;
 mod hotkey_system;
 mod image;

--- a/src/run/attempt.rs
+++ b/src/run/attempt.rs
@@ -30,9 +30,10 @@ impl Attempt {
     /// This either returns a 1.6+ Time Stamp based duration
     /// or the duration of the run (assuming it's not resetted)
     /// if it's from before LiveSplit 1.6. If it is from before
-    /// 1.6 and resetted then it will return null.
+    /// 1.6 and resetted then it will return None.
     pub fn duration(&self) -> Option<TimeSpan> {
-        AtomicDateTime::option_op(self.started, self.ended, |s, e| e - s).or(self.time.real_time)
+        let diff = catch! { self.ended? - self.started? };
+        diff.or(self.time.real_time)
     }
 
     #[inline]

--- a/src/run/editor/mod.rs
+++ b/src/run/editor/mod.rs
@@ -210,7 +210,7 @@ impl Editor {
         for segment in self.run.segments() {
             let split_time = segment.personal_best_split_time()[method];
             self.segment_times
-                .push(TimeSpan::option_sub(split_time, previous_time));
+                .push(catch! { split_time? - previous_time? });
             if split_time.is_some() {
                 previous_time = split_time;
             }
@@ -226,7 +226,7 @@ impl Editor {
         {
             {
                 let time = segment.personal_best_split_time_mut();
-                time[method] = TimeSpan::option_add(previous_time, *segment_time);
+                time[method] = catch! { previous_time? + (*segment_time)? };
             }
             if segment_time.is_some() {
                 previous_time = segment.personal_best_split_time()[method];
@@ -297,7 +297,7 @@ impl Editor {
                 let current_segment = segment_history_element[method];
                 if let Some(current_segment) = current_segment {
                     for current_index in current_index..self.run.len() {
-                        // Add the removed segment's history times to the next non null times
+                        // Add the removed segment's history times to the next non None times
                         if let Some(&mut Some(ref mut segment)) = self.run
                             .segment_mut(current_index)
                             .segment_history_mut()
@@ -318,10 +318,10 @@ impl Editor {
         }
 
         // Set the new Best Segment time to be the sum of the two Best Segments
-        let min_best_segment = TimeSpan::option_add(
-            self.run.segment(index).best_segment_time()[method],
-            self.run.segment(current_index).best_segment_time()[method],
-        );
+        let min_best_segment = catch! {
+            self.run.segment(index).best_segment_time()[method]?
+                + self.run.segment(current_index).best_segment_time()[method]?
+        };
 
         if let Some(mut min_best_segment) = min_best_segment {
             // Use any element in the history that has a lower time than this sum
@@ -387,7 +387,7 @@ impl Editor {
 
         for run_index in min_index..max_index + 1 {
             // Remove both segment history elements if one of them
-            // has a null time and the other has has a non null time
+            // has a None time and the other has has a non None time
             let first_history = first.segment_history().get(run_index);
             let second_history = second.segment_history().get(run_index);
             if let (Some(first_history), Some(second_history)) = (first_history, second_history) {

--- a/src/run/segment_history.rs
+++ b/src/run/segment_history.rs
@@ -9,7 +9,7 @@ impl SegmentHistory {
     pub fn try_get_min_index(&self) -> Option<i32> {
         // This assumes that the first element is the minimum,
         // which is only true for an ordered map
-        self.0.first().map(|&(i, _)| i)
+        Some(self.0.first()?.0)
     }
 
     /// Defaults to a maximum of 1
@@ -20,7 +20,7 @@ impl SegmentHistory {
     pub fn try_get_max_index(&self) -> Option<i32> {
         // This assumes that the last element is the maximum,
         // which is only true for an ordered map
-        self.0.last().map(|&(i, _)| i)
+        Some(self.0.last()?.0)
     }
 
     fn get_pos(&self, index: i32) -> Result<usize, usize> {
@@ -36,19 +36,14 @@ impl SegmentHistory {
 
     #[inline]
     pub fn get(&self, index: i32) -> Option<Time> {
-        self.get_pos(index)
-            .ok()
-            .and_then(|p| self.0.get(p))
-            .map(|&(_, t)| t)
+        let pos = self.get_pos(index).ok()?;
+        Some(self.0.get(pos)?.1)
     }
 
     #[inline]
     pub fn get_mut(&mut self, index: i32) -> Option<&mut Time> {
-        if let Ok(pos) = self.get_pos(index) {
-            Some(&mut self.0[pos].1)
-        } else {
-            None
-        }
+        let pos = self.get_pos(index).ok()?;
+        Some(&mut self.0.get_mut(pos)?.1)
     }
 
     #[inline]

--- a/src/time/atomic_date_time.rs
+++ b/src/time/atomic_date_time.rs
@@ -23,16 +23,6 @@ impl AtomicDateTime {
             synced_with_atomic_clock: false,
         }
     }
-
-    pub fn option_op<F, R>(a: Option<AtomicDateTime>, b: Option<AtomicDateTime>, f: F) -> Option<R>
-    where
-        F: FnOnce(AtomicDateTime, AtomicDateTime) -> R,
-    {
-        match (a, b) {
-            (Some(a), Some(b)) => Some(f(a, b)),
-            _ => None,
-        }
-    }
 }
 
 impl Sub for AtomicDateTime {

--- a/src/time/time.rs
+++ b/src/time/time.rs
@@ -52,8 +52,8 @@ impl Time {
         F: FnMut(TimeSpan, TimeSpan) -> TimeSpan,
     {
         Time {
-            real_time: TimeSpan::option_op(a.real_time, b.real_time, &mut f),
-            game_time: TimeSpan::option_op(a.game_time, b.game_time, &mut f),
+            real_time: catch! { f(a.real_time?, b.real_time?) },
+            game_time: catch! { f(a.game_time?, b.game_time?) },
         }
     }
 }

--- a/src/time/time_span.rs
+++ b/src/time/time_span.rs
@@ -26,24 +26,6 @@ impl TimeSpan {
         ))
     }
 
-    pub fn option_op<F, R>(a: Option<TimeSpan>, b: Option<TimeSpan>, f: F) -> Option<R>
-    where
-        F: FnOnce(TimeSpan, TimeSpan) -> R,
-    {
-        match (a, b) {
-            (Some(a), Some(b)) => Some(f(a, b)),
-            _ => None,
-        }
-    }
-
-    pub fn option_add(a: Option<TimeSpan>, b: Option<TimeSpan>) -> Option<TimeSpan> {
-        TimeSpan::option_op(a, b, |a, b| a + b)
-    }
-
-    pub fn option_sub(a: Option<TimeSpan>, b: Option<TimeSpan>) -> Option<TimeSpan> {
-        TimeSpan::option_op(a, b, |a, b| a - b)
-    }
-
     pub fn to_duration(&self) -> Duration {
         self.0
     }

--- a/src/time/timer.rs
+++ b/src/time/timer.rs
@@ -105,15 +105,10 @@ impl Timer {
             Ended => self.run.segments().last().unwrap().split_time().game_time,
             _ => if self.is_game_time_paused() {
                 self.game_time_pause_time
+            } else if self.is_game_time_initialized() {
+                catch! { real_time? - self.loading_times() }
             } else {
-                TimeSpan::option_sub(
-                    real_time,
-                    if self.is_game_time_initialized() {
-                        Some(self.loading_times())
-                    } else {
-                        None
-                    },
-                )
+                None
             },
         };
 
@@ -388,10 +383,8 @@ impl Timer {
     pub fn unpause_game_time(&mut self) {
         if self.is_game_time_paused() {
             let current_time = self.current_time();
-            self.set_loading_times(
-                TimeSpan::option_sub(current_time.real_time, current_time.game_time)
-                    .unwrap_or_default(),
-            );
+            let diff = catch! { current_time.real_time? - current_time.game_time? };
+            self.set_loading_times(diff.unwrap_or_default());
             self.is_game_time_paused = false;
         }
     }


### PR DESCRIPTION
With the recent introduction of the question mark operator for Options, we can now clean up the codebase a lot by using small catch blocks, instead of using option_op, map, and_then, if let, etc. all over the place.

Closes #84 