### PR TITLE
Modify add_custom_comparison to return Result

### DIFF
--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -29,13 +29,7 @@ mod tests;
 
 pub use self::attempt::Attempt;
 pub use self::run_metadata::RunMetadata;
-pub use self::run::{ComparisonsIter, Run};
+pub use self::run::{ComparisonError, ComparisonsIter, Run};
 pub use self::segment_history::SegmentHistory;
 pub use self::segment::Segment;
 pub use self::editor::Editor;
-
-/// Checks a given name against the current comparisons in the Run to
-/// ensure that it is valid for use.
-pub fn validate_comparison_name(run: &Run, new: &str) -> bool {
-    !new.starts_with("[Race]") && !run.comparisons().any(|c| c == new)
-}

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -32,4 +32,4 @@ pub use self::run_metadata::RunMetadata;
 pub use self::run::{ComparisonError, ComparisonsIter, Run};
 pub use self::segment_history::SegmentHistory;
 pub use self::segment::Segment;
-pub use self::editor::Editor;
+pub use self::editor::{Editor, RenameError};

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -33,3 +33,9 @@ pub use self::run::{ComparisonsIter, Run};
 pub use self::segment_history::SegmentHistory;
 pub use self::segment::Segment;
 pub use self::editor::Editor;
+
+/// Checks a given name against the current comparisons in the Run to
+/// ensure that it is valid for use.
+pub fn validate_comparison_name(run: &Run, new: &str) -> bool {
+    !new.starts_with("[Race]") && !run.comparisons().any(|c| c == new)
+}

--- a/src/run/parser/livesplit.rs
+++ b/src/run/parser/livesplit.rs
@@ -211,7 +211,8 @@ fn parse_segment<R: BufRead>(
                                 *segment.comparison_mut(&comparison) = t;
                             })?;
                         }
-                        run.add_custom_comparison(comparison);
+                        let _ = run.add_custom_comparison(comparison)
+                            .map_err(|_| Error::InvalidComparisonName);
                         Ok(())
                     } else {
                         end_tag(reader, tag.into_buf())

--- a/src/run/parser/livesplit.rs
+++ b/src/run/parser/livesplit.rs
@@ -211,8 +211,7 @@ fn parse_segment<R: BufRead>(
                                 *segment.comparison_mut(&comparison) = t;
                             })?;
                         }
-                        let _ = run.add_custom_comparison(comparison)
-                            .map_err(|_| Error::InvalidComparisonName);
+                        run.add_custom_comparison(comparison).map_err(|_| {});
                         Ok(())
                     } else {
                         end_tag(reader, tag.into_buf())

--- a/src/run/parser/livesplit.rs
+++ b/src/run/parser/livesplit.rs
@@ -3,6 +3,7 @@
 use std::io::BufRead;
 use std::path::PathBuf;
 use {AtomicDateTime, Run, RunMetadata, Segment, Time, TimeSpan, base64};
+use super::super::run::ComparisonError;
 use quick_xml::reader::Reader;
 use chrono::{DateTime, TimeZone, Utc};
 use std::str;
@@ -211,7 +212,11 @@ fn parse_segment<R: BufRead>(
                                 *segment.comparison_mut(&comparison) = t;
                             })?;
                         }
-                        run.add_custom_comparison(comparison).map_err(|_| {});
+                        if let Err(ComparisonError::NameStartsWithRace) =
+                            run.add_custom_comparison(comparison)
+                        {
+                            return Err(ComparisonError::NameStartsWithRace.into());
+                        }
                         Ok(())
                     } else {
                         end_tag(reader, tag.into_buf())

--- a/src/run/parser/time_split_tracker.rs
+++ b/src/run/parser/time_split_tracker.rs
@@ -31,6 +31,10 @@ quick_error! {
         ExpectedComparisonTime {}
         /// Expected the line containing the icon, but didn't find it.
         ExpectedIconLine {}
+        /// Parsed comparison has an invalid name.
+        InvalidComparisonName {
+            from()
+        }
         /// Failed to parse an integer.
         Int(err: ParseIntError) {
             from()
@@ -124,7 +128,8 @@ pub fn parse<R: BufRead>(source: R, path_for_loading_other_files: Option<PathBuf
     parse_history(&mut run, path).ok();
 
     for comparison in comparisons {
-        run.add_custom_comparison(comparison);
+        let _ = run.add_custom_comparison(comparison)
+            .map_err(|_| Error::InvalidComparisonName);
     }
 
     Ok(run)

--- a/src/run/parser/wsplit.rs
+++ b/src/run/parser/wsplit.rs
@@ -120,7 +120,8 @@ pub fn parse<R: BufRead>(source: R, load_icons: bool) -> Result<Run> {
     }
 
     if old_run_exists {
-        run.add_custom_comparison("Old Run").expect("WSplit: Old Run");
+        run.add_custom_comparison("Old Run")
+            .expect("WSplit: Old Run");
     }
 
     for (icon, segment) in icons_list.into_iter().zip(run.segments_mut().iter_mut()) {

--- a/src/run/parser/wsplit.rs
+++ b/src/run/parser/wsplit.rs
@@ -120,7 +120,7 @@ pub fn parse<R: BufRead>(source: R, load_icons: bool) -> Result<Run> {
     }
 
     if old_run_exists {
-        run.add_custom_comparison("Old Run");
+        run.add_custom_comparison("Old Run").expect("WSplit: Old Run");
     }
 
     for (icon, segment) in icons_list.into_iter().zip(run.segments_mut().iter_mut()) {

--- a/src/run/parser/xml_util.rs
+++ b/src/run/parser/xml_util.rs
@@ -35,6 +35,10 @@ quick_error! {
         ElementNotFound {}
         /// The length of a buffer was too large.
         LengthOutOfBounds {}
+        /// Parsed comparison has an invalid name.
+        InvalidComparisonName {
+            from()
+        }
         /// Failed to decode a string slice as UTF-8.
         Utf8Str(err: str::Utf8Error) {
             from()

--- a/src/run/parser/xml_util.rs
+++ b/src/run/parser/xml_util.rs
@@ -10,6 +10,7 @@ use std::result::Result as StdResult;
 use std::num::{ParseFloatError, ParseIntError};
 use time;
 use chrono::ParseError as ChronoError;
+use super::super::ComparisonError;
 
 quick_error! {
     /// The Error type for XML-based splits files that couldn't be parsed.
@@ -36,7 +37,7 @@ quick_error! {
         /// The length of a buffer was too large.
         LengthOutOfBounds {}
         /// Parsed comparison has an invalid name.
-        InvalidComparisonName {
+        InvalidComparisonName(err: ComparisonError) {
             from()
         }
         /// Failed to decode a string slice as UTF-8.

--- a/src/run/run.rs
+++ b/src/run/run.rs
@@ -3,6 +3,7 @@ use std::cmp::max;
 use std::collections::HashSet;
 use std::path::PathBuf;
 use {AtomicDateTime, Attempt, Image, RunMetadata, Segment, Time, TimeSpan, TimingMethod};
+use super::validate_comparison_name;
 use comparison::{default_generators, personal_best, ComparisonGenerator};
 use ordered_float::OrderedFloat;
 use unicase;
@@ -341,10 +342,13 @@ impl Run {
     /// Adds a new custom comparison. If a custom comparison with that name
     /// already exists, it is not added.
     #[inline]
-    pub fn add_custom_comparison<S: Into<String>>(&mut self, comparison: S) {
+    pub fn add_custom_comparison<S: Into<String>>(&mut self, comparison: S) -> Result<(), ()> {
         let comparison = comparison.into();
-        if !self.custom_comparisons.contains(&comparison) {
+        if validate_comparison_name(&self, &comparison) {
             self.custom_comparisons.push(comparison);
+            Ok(())
+        } else {
+            Err(())
         }
     }
 

--- a/tests/parsing.rs
+++ b/tests/parsing.rs
@@ -97,7 +97,8 @@ mod parse {
 
     #[test]
     fn time_split_tracker() {
-        time_split_tracker::parse(file("tests/run_files/timesplittracker.txt"), None).unwrap();
+        let run = time_split_tracker::parse(file("tests/run_files/timesplittracker.txt"), None).unwrap();
+        assert_eq!(run.custom_comparisons(), ["Personal Best", "Time", "Custom Comparison", "Race", "Race2"]);
     }
 
     #[test]

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -1,0 +1,48 @@
+extern crate livesplit_core;
+
+mod run {
+    use livesplit_core::{Run, Segment};
+    use livesplit_core::run::Editor;
+
+    #[test]
+    fn add_comparison() {
+        let mut run = Run::new();
+        let c = run.add_custom_comparison("My Comparison");
+        assert_eq!(c, Ok(()));
+    }
+
+    #[test]
+    fn add_duplicate_comparison() {
+        let mut run = Run::new();
+        let c = run.add_custom_comparison("Best Segments");
+        assert_eq!(c, Err(()));
+    }
+
+    #[test]
+    fn add_comparison_editor() {
+        let mut run = Run::new();
+        run.push_segment(Segment::new("s"));
+        let mut editor = Editor::new(run).unwrap();
+        let c = editor.add_comparison("My Comparison");
+        assert_eq!(c, Ok(()));
+    }
+
+    #[test]
+    fn add_duplicate_comparison_editor() {
+        let mut run = Run::new();
+        run.push_segment(Segment::new("s"));
+        let mut editor = Editor::new(run).unwrap();
+        let c = editor.add_comparison("Best Segments");
+        assert_eq!(c, Err(()));
+    }
+
+    #[test]
+    fn rename_comparison_editor() {
+        let mut run = Run::new();
+        run.push_segment(Segment::new("s"));
+        run.add_custom_comparison("Custom").ok();
+        let mut editor = Editor::new(run).unwrap();
+        let c = editor.rename_comparison("Custom", "My Comparison");
+        assert_eq!(c, Ok(()));
+    }
+}

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -2,7 +2,7 @@ extern crate livesplit_core;
 
 mod run {
     use livesplit_core::{Run, Segment};
-    use livesplit_core::run::Editor;
+    use livesplit_core::run::{ComparisonError, Editor};
 
     #[test]
     fn add_comparison() {
@@ -15,7 +15,7 @@ mod run {
     fn add_duplicate_comparison() {
         let mut run = Run::new();
         let c = run.add_custom_comparison("Best Segments");
-        assert_eq!(c, Err(()));
+        assert_eq!(c, Err(ComparisonError::DuplicateName));
     }
 
     #[test]
@@ -33,7 +33,7 @@ mod run {
         run.push_segment(Segment::new("s"));
         let mut editor = Editor::new(run).unwrap();
         let c = editor.add_comparison("Best Segments");
-        assert_eq!(c, Err(()));
+        assert_eq!(c, Err(ComparisonError::DuplicateName));
     }
 
     #[test]

--- a/tests/run_files/timesplittracker.txt
+++ b/tests/run_files/timesplittracker.txt
@@ -1,34 +1,34 @@
 31	0.00	
-A Link to the Past 100% No S+Q 	Best Splits	Time
-Hyrule Castle	6:17.06	6:17.06
+A Link to the Past 100% No S+Q 	Best Splits	Time	Custom Comparison	[Race]Race	Race
+Hyrule Castle	6:17.06	6:17.06	6:17.06	6:17.06	6:17.06
 images/Priest.png		
-Eastern Palace	5:42.05	12:10.12
+Eastern Palace	5:42.05	12:10.12	6:17.06	6:17.06	6:17.06
 images/eastern.png		
-Desert Palace	7:47.07	19:57.19
+Desert Palace	7:47.07	19:57.19	6:17.06	6:17.06	6:17.06
 images/desert.png		
-Tower of hera	7:58.07	27:55.27
+Tower of hera	7:58.07	27:55.27	6:17.06	6:17.06	6:17.06
 images/hera.png		
-Light World	9:24.09	37:20.37
+Light World	9:24.09	37:20.37	6:17.06	6:17.06	6:17.06
 images/lightworld.png		
-Dark Palace	7:25.07	44:45.44
+Dark Palace	7:25.07	44:45.44	6:17.06	6:17.06	6:17.06
 images/helm.png		
-Dig	7:08.07	52:24.52
+Dig	7:08.07	52:24.52	6:17.06	6:17.06	6:17.06
 images/dig.png		
-Chest	5:31.05	57:55.57
+Chest	5:31.05	57:55.57	6:17.06	6:17.06	6:17.06
 images/chest.png		
-Thieves’ Town	5:27.05	1:03:22.73
+Thieves’ Town	5:27.05	1:03:22.73	6:17.06	6:17.06	6:17.06
 images/thieves.png		
-Skull Woods	8:11.08	1:11:34.13
+Skull Woods	8:11.08	1:11:34.13	6:17.06	6:17.06	6:17.06
 images/skullwoods.png		
-Ice Palace	9:21.09	1:20:55.88
+Ice Palace	9:21.09	1:20:55.88	6:17.06	6:17.06	6:17.06
 images/ice.png		
-Misery Mire	10:55.10	1:31:51.65
+Misery Mire	10:55.10	1:31:51.65	6:17.06	6:17.06	6:17.06
 images/swamp.png		
-Swamp Palace	9:52.09	1:41:51.06
+Swamp Palace	9:52.09	1:41:51.06	6:17.06	6:17.06	6:17.06
 images/water.png		
-Turtle Rock	18:35.18	2:00:26.24
+Turtle Rock	18:35.18	2:00:26.24	6:17.06	6:17.06	6:17.06
 images/turtle.png		
-Dark World	11:26.11	2:11:52.36
+Dark World	11:26.11	2:11:52.36	6:17.06	6:17.06	6:17.06
 images/gtower.png		
-Triforce	2:13.02	2:14:06.00
+Triforce	2:13.02	2:14:06.00	6:17.06	6:17.06	6:17.06
 images/triforce.png		


### PR DESCRIPTION
Changed add_custom_comparison to return a result to provide feedback for
whether or not it added it successfully, as well as incorperated name and
duplicate checking into the function instead of in a seperate method.