### PR TITLE
WIP Cross-platform support.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,12 +73,13 @@ vek = { version = "0.9.8", default-features = false, optional = true }
 # Networking
 splits-io-api = { version = "0.1.2", optional = true }
 
+# Auto Splitting
+livesplit-auto-splitting = { path = "crates/livesplit-auto-splitting", version = "0.1.0", optional = true }
+crossbeam-channel = { version = "0.3.6", default-features = false, optional = true }
+
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 # WebAssembly in the Web
 web-sys = { version = "0.3.28", default-features = false, features = ["Performance", "Window"], optional = true }
-
-# Auto Splitting
-livesplit-auto-splitting = { path = "crates/livesplit-auto-splitting", version = "0.1.0", optional = true }
 
 [dev-dependencies]
 memmem = "0.1.1"
@@ -96,7 +97,7 @@ rendering = ["std", "more-image-formats", "euclid", "livesplit-title-abbreviatio
 software-rendering = ["rendering", "euc", "vek", "derive_more/mul"]
 wasm-web = ["std", "web-sys", "chrono/wasmbind", "livesplit-hotkey/wasm-web"]
 networking = ["std", "splits-io-api"]
-auto-splitting = ["std", "livesplit-auto-splitting"]
+auto-splitting = ["std", "livesplit-auto-splitting", "crossbeam-channel"]
 
 # FIXME: Some targets don't have atomics, but we can't test for this properly
 # yet. So there's a feature you explicitly have to opt into to deactivate the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ splits-io-api = { version = "0.1.2", optional = true }
 # Auto Splitting
 livesplit-auto-splitting = { path = "crates/livesplit-auto-splitting", version = "0.1.0", optional = true }
 crossbeam-channel = { version = "0.3.6", default-features = false, optional = true }
+log = { version = "0.4.6", optional = true }
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 # WebAssembly in the Web
@@ -97,7 +98,7 @@ rendering = ["std", "more-image-formats", "euclid", "livesplit-title-abbreviatio
 software-rendering = ["rendering", "euc", "vek", "derive_more/mul"]
 wasm-web = ["std", "web-sys", "chrono/wasmbind", "livesplit-hotkey/wasm-web"]
 networking = ["std", "splits-io-api"]
-auto-splitting = ["std", "livesplit-auto-splitting", "crossbeam-channel"]
+auto-splitting = ["std", "livesplit-auto-splitting", "crossbeam-channel", "log"]
 
 # FIXME: Some targets don't have atomics, but we can't test for this properly
 # yet. So there's a feature you explicitly have to opt into to deactivate the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,9 @@ splits-io-api = { version = "0.1.2", optional = true }
 # WebAssembly in the Web
 web-sys = { version = "0.3.28", default-features = false, features = ["Performance", "Window"], optional = true }
 
+# Auto Splitting
+livesplit-auto-splitting = { path = "crates/livesplit-auto-splitting", version = "0.1.0", optional = true }
+
 [dev-dependencies]
 memmem = "0.1.1"
 criterion = "0.3.0"
@@ -93,6 +96,7 @@ rendering = ["std", "more-image-formats", "euclid", "livesplit-title-abbreviatio
 software-rendering = ["rendering", "euc", "vek", "derive_more/mul"]
 wasm-web = ["std", "web-sys", "chrono/wasmbind", "livesplit-hotkey/wasm-web"]
 networking = ["std", "splits-io-api"]
+auto-splitting = ["std", "livesplit-auto-splitting"]
 
 # FIXME: Some targets don't have atomics, but we can't test for this properly
 # yet. So there's a feature you explicitly have to opt into to deactivate the

--- a/crates/livesplit-auto-splitting/Cargo.toml
+++ b/crates/livesplit-auto-splitting/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "livesplit-auto-splitting"
+version = "0.1.0"
+authors = ["Christopher Serr <christopher.serr@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+wasmi = "0.3.0"
+num-traits = "0.2.5"
+num-derive = "0.2.2"
+quick-error = "1.2.2"
+winapi = { version = "0.3.5", features = ["handleapi", "memoryapi", "processthreadsapi", "tlhelp32", "winnt", "wow64apiset"] }
+itertools = "0.8.0"

--- a/crates/livesplit-auto-splitting/Cargo.toml
+++ b/crates/livesplit-auto-splitting/Cargo.toml
@@ -11,3 +11,4 @@ num-derive = "0.2.2"
 quick-error = "1.2.2"
 winapi = { version = "0.3.5", features = ["handleapi", "memoryapi", "processthreadsapi", "tlhelp32", "winnt", "wow64apiset"] }
 itertools = "0.8.0"
+log = "0.4.6"

--- a/crates/livesplit-auto-splitting/Cargo.toml
+++ b/crates/livesplit-auto-splitting/Cargo.toml
@@ -6,12 +6,11 @@ edition = "2018"
 
 [dependencies]
 # wasmi = "0.3.0"
-wasmer-runtime = { path = "../../../wasmer/lib/runtime" }
-wasmer-runtime-core = { path = "../../../wasmer/lib/runtime-core" }
+# wasmer-runtime = { path = "../../../wasmer/lib/runtime" }
+# wasmer-runtime-core = { path = "../../../wasmer/lib/runtime-core" }
 # wasmer-runtime = { git = "https://github.com/wasmerio/wasmer" }
-# wasmer-runtime-core = { git = "https://github.com/wasmerio/wasmer" }
-# wasmer-runtime = "0.4.2"
-# wasmer-runtime-core = "0.4.2"
+wasmer-runtime = "0.5.7"
+wasmer-runtime-core = "0.5.7"
 # wasmer-runtime = { git = "https://github.com/CryZe/wasmer", branch = "windows-calling-conventions" }
 num-traits = "0.2.5"
 num-derive = "0.2.2"

--- a/crates/livesplit-auto-splitting/Cargo.toml
+++ b/crates/livesplit-auto-splitting/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2018"
 # wasmer-runtime = { path = "../../../wasmer/lib/runtime" }
 # wasmer-runtime-core = { path = "../../../wasmer/lib/runtime-core" }
 # wasmer-runtime = { git = "https://github.com/wasmerio/wasmer" }
-wasmer-runtime = "0.5.7"
-wasmer-runtime-core = "0.5.7"
+wasmer-runtime = "0.13.1"
+wasmer-runtime-core = "0.13.1"
 # wasmer-runtime = { git = "https://github.com/CryZe/wasmer", branch = "windows-calling-conventions" }
 num-traits = "0.2.5"
 num-derive = "0.2.2"

--- a/crates/livesplit-auto-splitting/Cargo.toml
+++ b/crates/livesplit-auto-splitting/Cargo.toml
@@ -24,3 +24,4 @@ rand = "0.6.5"
 
 proc-maps = "0.1.6"
 read-process-memory = "0.1.2"
+sysinfo = "0.9.0"

--- a/crates/livesplit-auto-splitting/Cargo.toml
+++ b/crates/livesplit-auto-splitting/Cargo.toml
@@ -6,8 +6,9 @@ edition = "2018"
 
 [dependencies]
 # wasmi = "0.3.0"
-wasmer-runtime = { path = "../../../wasmer/lib/runtime" }
+# wasmer-runtime = { path = "../../../wasmer/lib/runtime" }
 # wasmer-runtime = { git = "https://github.com/wasmerio/wasmer" }
+wasmer-runtime = "0.3.0"
 # wasmer-runtime = { git = "https://github.com/CryZe/wasmer", branch = "windows-calling-conventions" }
 num-traits = "0.2.5"
 num-derive = "0.2.2"

--- a/crates/livesplit-auto-splitting/Cargo.toml
+++ b/crates/livesplit-auto-splitting/Cargo.toml
@@ -6,10 +6,12 @@ edition = "2018"
 
 [dependencies]
 # wasmi = "0.3.0"
-# wasmer-runtime = { path = "../../../wasmer/lib/runtime" }
+wasmer-runtime = { path = "../../../wasmer/lib/runtime" }
+wasmer-runtime-core = { path = "../../../wasmer/lib/runtime-core" }
 # wasmer-runtime = { git = "https://github.com/wasmerio/wasmer" }
-wasmer-runtime = "0.3.0"
-wasmer-runtime-core = "0.3.0"
+# wasmer-runtime-core = { git = "https://github.com/wasmerio/wasmer" }
+# wasmer-runtime = "0.4.2"
+# wasmer-runtime-core = "0.4.2"
 # wasmer-runtime = { git = "https://github.com/CryZe/wasmer", branch = "windows-calling-conventions" }
 num-traits = "0.2.5"
 num-derive = "0.2.2"

--- a/crates/livesplit-auto-splitting/Cargo.toml
+++ b/crates/livesplit-auto-splitting/Cargo.toml
@@ -6,7 +6,8 @@ edition = "2018"
 
 [dependencies]
 # wasmi = "0.3.0"
-wasmer-runtime = { git = "https://github.com/wasmerio/wasmer" }
+wasmer-runtime = { path = "../../../wasmer/lib/runtime" }
+# wasmer-runtime = { git = "https://github.com/wasmerio/wasmer" }
 # wasmer-runtime = { git = "https://github.com/CryZe/wasmer", branch = "windows-calling-conventions" }
 num-traits = "0.2.5"
 num-derive = "0.2.2"

--- a/crates/livesplit-auto-splitting/Cargo.toml
+++ b/crates/livesplit-auto-splitting/Cargo.toml
@@ -16,8 +16,11 @@ wasmer-runtime-core = { path = "../../../wasmer/lib/runtime-core" }
 num-traits = "0.2.5"
 num-derive = "0.2.2"
 quick-error = "1.2.2"
-winapi = { version = "0.3.5", features = ["handleapi", "memoryapi", "processthreadsapi", "psapi", "tlhelp32", "winnt", "wow64apiset"] }
+# winapi = { version = "0.3.5", features = ["handleapi", "memoryapi", "processthreadsapi", "psapi", "tlhelp32", "winnt", "wow64apiset"] }
 itertools = "0.8.0"
 log = "0.4.6"
 lazy_static = "1.3.0"
 rand = "0.6.5"
+
+proc-maps = "0.1.6"
+read-process-memory = "0.1.2"

--- a/crates/livesplit-auto-splitting/Cargo.toml
+++ b/crates/livesplit-auto-splitting/Cargo.toml
@@ -16,7 +16,6 @@ wasmer-runtime-core = { path = "../../../wasmer/lib/runtime-core" }
 num-traits = "0.2.5"
 num-derive = "0.2.2"
 quick-error = "1.2.2"
-# winapi = { version = "0.3.5", features = ["handleapi", "memoryapi", "processthreadsapi", "psapi", "tlhelp32", "winnt", "wow64apiset"] }
 itertools = "0.8.0"
 log = "0.4.6"
 lazy_static = "1.3.0"

--- a/crates/livesplit-auto-splitting/Cargo.toml
+++ b/crates/livesplit-auto-splitting/Cargo.toml
@@ -5,7 +5,9 @@ authors = ["Christopher Serr <christopher.serr@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-wasmi = "0.3.0"
+# wasmi = "0.3.0"
+wasmer-runtime = { git = "https://github.com/wasmerio/wasmer" }
+# wasmer-runtime = { git = "https://github.com/CryZe/wasmer", branch = "windows-calling-conventions" }
 num-traits = "0.2.5"
 num-derive = "0.2.2"
 quick-error = "1.2.2"

--- a/crates/livesplit-auto-splitting/Cargo.toml
+++ b/crates/livesplit-auto-splitting/Cargo.toml
@@ -9,10 +9,13 @@ edition = "2018"
 # wasmer-runtime = { path = "../../../wasmer/lib/runtime" }
 # wasmer-runtime = { git = "https://github.com/wasmerio/wasmer" }
 wasmer-runtime = "0.3.0"
+wasmer-runtime-core = "0.3.0"
 # wasmer-runtime = { git = "https://github.com/CryZe/wasmer", branch = "windows-calling-conventions" }
 num-traits = "0.2.5"
 num-derive = "0.2.2"
 quick-error = "1.2.2"
-winapi = { version = "0.3.5", features = ["handleapi", "memoryapi", "processthreadsapi", "tlhelp32", "winnt", "wow64apiset"] }
+winapi = { version = "0.3.5", features = ["handleapi", "memoryapi", "processthreadsapi", "psapi", "tlhelp32", "winnt", "wow64apiset"] }
 itertools = "0.8.0"
 log = "0.4.6"
+lazy_static = "1.3.0"
+rand = "0.6.5"

--- a/crates/livesplit-auto-splitting/src/environment.rs
+++ b/crates/livesplit-auto-splitting/src/environment.rs
@@ -1,0 +1,407 @@
+use crate::pointer::{PointerType, PointerValue};
+use crate::process::Process;
+use num_traits::FromPrimitive;
+use std::{fmt, str, time::Duration};
+use wasmi::{
+    nan_preserving_float::F64, Error, Externals, FuncInstance, FuncRef, GlobalDescriptor,
+    GlobalRef, HostError, ImportResolver, MemoryDescriptor, MemoryRef, RuntimeArgs, RuntimeValue,
+    Signature, TableDescriptor, TableRef, Trap, TrapKind, ValueType,
+};
+
+const SET_PROCESS_NAME_FUNC_INDEX: usize = 0;
+const PUSH_POINTER_PATH_FUNC_INDEX: usize = 1;
+const PUSH_OFFSET_FUNC_INDEX: usize = 2;
+const GET_U8_FUNC_INDEX: usize = 3;
+const GET_U16_FUNC_INDEX: usize = 4;
+const GET_U32_FUNC_INDEX: usize = 5;
+const GET_U64_FUNC_INDEX: usize = 6;
+const GET_I8_FUNC_INDEX: usize = 7;
+const GET_I16_FUNC_INDEX: usize = 8;
+const GET_I32_FUNC_INDEX: usize = 9;
+const GET_I64_FUNC_INDEX: usize = 10;
+const GET_F32_FUNC_INDEX: usize = 11;
+const GET_F64_FUNC_INDEX: usize = 12;
+const SCAN_SIGNATURE_FUNC_INDEX: usize = 13;
+const SET_TICK_RATE_FUNC_INDEX: usize = 14;
+const PRINT_MESSAGE_FUNC_INDEX: usize = 15;
+const READ_INTO_BUF_FUNC_INDEX: usize = 16;
+
+#[derive(Debug)]
+enum EnvironmentError {
+    InvalidProcessName,
+    InvalidModuleName,
+    InvalidPointerPathId,
+    InvalidPointerType,
+    TypeMismatch,
+    Utf8DecodeError,
+}
+
+impl fmt::Display for EnvironmentError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            EnvironmentError::InvalidProcessName => write!(f, "Invalid process name"),
+            EnvironmentError::InvalidModuleName => {
+                write!(f, "Invalid module name provided to construct pointer path")
+            }
+            EnvironmentError::InvalidPointerPathId => write!(f, "Invalid pointer path id provided"),
+            EnvironmentError::InvalidPointerType => write!(f, "Invalid pointer type provided"),
+            EnvironmentError::TypeMismatch => {
+                write!(f, "Attempt to read from a value of the wrong type")
+            }
+            EnvironmentError::Utf8DecodeError => {
+                write!(f, "The provided string was not valid UTF-8")
+            }
+        }
+    }
+}
+
+impl HostError for EnvironmentError {}
+
+#[derive(Debug)]
+pub struct Environment {
+    memory: MemoryRef,
+    pub process_name: String,
+    // TODO Undo pub
+    pub pointer_paths: Vec<PointerPath>,
+    pub tick_rate: Duration,
+    pub process: Option<Process>,
+}
+
+#[derive(Debug)]
+pub struct PointerPath {
+    pub module_name: String,
+    pub offsets: Vec<i64>,
+    // TODO Undo pub
+    pub current: PointerValue,
+    pub old: PointerValue,
+}
+
+impl Environment {
+    pub fn new(memory: MemoryRef) -> Self {
+        Self {
+            memory,
+            process_name: String::new(),
+            pointer_paths: Vec::new(),
+            tick_rate: Duration::from_secs(1) / 60,
+            process: None,
+        }
+    }
+}
+
+impl Externals for Environment {
+    fn invoke_index(
+        &mut self,
+        index: usize,
+        args: RuntimeArgs,
+    ) -> Result<Option<RuntimeValue>, Trap> {
+        match index {
+            SET_PROCESS_NAME_FUNC_INDEX => {
+                let ptr: u32 = args.nth_checked(0)?;
+                let ptr = ptr as usize;
+                let len: u32 = args.nth_checked(1)?;
+                let len = len as usize;
+
+                self.process_name = self
+                    .memory
+                    .with_direct_access(|m| {
+                        Some(str::from_utf8(m.get(ptr..ptr + len)?).ok()?.to_owned())
+                    })
+                    .ok_or_else(|| {
+                        Trap::new(TrapKind::Host(Box::new(
+                            EnvironmentError::InvalidProcessName,
+                        )))
+                    })?;
+
+                Ok(None)
+            }
+            PUSH_POINTER_PATH_FUNC_INDEX => {
+                let ptr: u32 = args.nth_checked(0)?;
+                let ptr = ptr as usize;
+                let len: u32 = args.nth_checked(1)?;
+                let len = len as usize;
+                let pointer_type: u8 = args.nth_checked(2)?;
+                let pointer_type = PointerType::from_u8(pointer_type)
+                    .ok_or_else(|| EnvironmentError::InvalidPointerType)?;
+                let current = match pointer_type {
+                    PointerType::U8 => PointerValue::U8(0),
+                    PointerType::U16 => PointerValue::U16(0),
+                    PointerType::U32 => PointerValue::U32(0),
+                    PointerType::U64 => PointerValue::U64(0),
+                    PointerType::I8 => PointerValue::I8(0),
+                    PointerType::I16 => PointerValue::I16(0),
+                    PointerType::I32 => PointerValue::I32(0),
+                    PointerType::I64 => PointerValue::I64(0),
+                    PointerType::F32 => PointerValue::F32(0.0),
+                    PointerType::F64 => PointerValue::F64(0.0),
+                    PointerType::String => PointerValue::String(String::new()),
+                };
+
+                let module_name = self
+                    .memory
+                    .with_direct_access(|m| {
+                        Some(str::from_utf8(m.get(ptr..ptr + len)?).ok()?.to_owned())
+                    })
+                    .ok_or_else(|| EnvironmentError::InvalidModuleName)?;
+
+                let id = self.pointer_paths.len();
+                self.pointer_paths.push(PointerPath {
+                    module_name,
+                    offsets: Vec::new(),
+                    old: current.clone(),
+                    current,
+                });
+
+                Ok(Some(RuntimeValue::I32(id as i32)))
+            }
+            PUSH_OFFSET_FUNC_INDEX => {
+                let pointer_path_id: u32 = args.nth_checked(0)?;
+                let pointer_path_id = pointer_path_id as usize;
+                let offset: i64 = args.nth_checked(1)?;
+                let pointer_path = self
+                    .pointer_paths
+                    .get_mut(pointer_path_id)
+                    .ok_or_else(|| EnvironmentError::InvalidPointerPathId)?;
+                pointer_path.offsets.push(offset);
+                Ok(None)
+            }
+            GET_U8_FUNC_INDEX => get_val(args, &self.pointer_paths, |v| match v {
+                PointerValue::U8(v) => Some(RuntimeValue::I32(*v as i32)),
+                _ => None,
+            }),
+            GET_U16_FUNC_INDEX => get_val(args, &self.pointer_paths, |v| match v {
+                PointerValue::U16(v) => Some(RuntimeValue::I32(*v as i32)),
+                _ => None,
+            }),
+            GET_U32_FUNC_INDEX => get_val(args, &self.pointer_paths, |v| match v {
+                PointerValue::U32(v) => Some(RuntimeValue::I32(*v as i32)),
+                _ => None,
+            }),
+            GET_U64_FUNC_INDEX => get_val(args, &self.pointer_paths, |v| match v {
+                PointerValue::U64(v) => Some(RuntimeValue::I64(*v as i64)),
+                _ => None,
+            }),
+            GET_I8_FUNC_INDEX => get_val(args, &self.pointer_paths, |v| match v {
+                PointerValue::I8(v) => Some(RuntimeValue::I32(*v as i32)),
+                _ => None,
+            }),
+            GET_I16_FUNC_INDEX => get_val(args, &self.pointer_paths, |v| match v {
+                PointerValue::I16(v) => Some(RuntimeValue::I32(*v as i32)),
+                _ => None,
+            }),
+            GET_I32_FUNC_INDEX => get_val(args, &self.pointer_paths, |v| match v {
+                PointerValue::I32(v) => Some(RuntimeValue::I32(*v)),
+                _ => None,
+            }),
+            GET_I64_FUNC_INDEX => get_val(args, &self.pointer_paths, |v| match v {
+                PointerValue::I64(v) => Some(RuntimeValue::I64(*v)),
+                _ => None,
+            }),
+            GET_F32_FUNC_INDEX => get_val(args, &self.pointer_paths, |v| match v {
+                &PointerValue::F32(v) => Some(RuntimeValue::F32(v.into())),
+                _ => None,
+            }),
+            GET_F64_FUNC_INDEX => get_val(args, &self.pointer_paths, |v| match v {
+                &PointerValue::F64(v) => Some(RuntimeValue::F64(v.into())),
+                _ => None,
+            }),
+            SCAN_SIGNATURE_FUNC_INDEX => {
+                let ptr: u32 = args.nth_checked(0)?;
+                let ptr = ptr as usize;
+                let len: u32 = args.nth_checked(1)?;
+                let len = len as usize;
+                let result = self
+                    .memory
+                    .with_direct_access(|m| {
+                        let signature = str::from_utf8(m.get(ptr..ptr + len)?).ok()?;
+                        self.process.as_ref().map(|p| p.scan_signature(signature))
+                    })
+                    .ok_or_else(|| EnvironmentError::Utf8DecodeError)?
+                    .ok() // TODO: Better handling of memory read errors.
+                    .and_then(|x| x);
+                Ok(Some(RuntimeValue::I64(result.unwrap_or(0) as i64)))
+            }
+            SET_TICK_RATE_FUNC_INDEX => {
+                let ticks_per_sec: F64 = args.nth_checked(0)?;
+                self.tick_rate = Duration::from_nanos(
+                    (1_000_000_000.0 / ticks_per_sec.to_float()).round() as u64,
+                );
+                Ok(None)
+            }
+            PRINT_MESSAGE_FUNC_INDEX => {
+                let ptr: u32 = args.nth_checked(0)?;
+                let ptr = ptr as usize;
+                let len: u32 = args.nth_checked(1)?;
+                let len = len as usize;
+                self.memory
+                    .with_direct_access(|m| {
+                        let message = str::from_utf8(m.get(ptr..ptr + len)?).ok()?;
+                        println!("{}", message);
+                        Some(())
+                    })
+                    .ok_or_else(|| EnvironmentError::Utf8DecodeError)?;
+
+                Ok(None)
+            }
+            READ_INTO_BUF_FUNC_INDEX => {
+                let address: i64 = args.nth_checked(0)?;
+                let address = address as u64;
+                let buf: u32 = args.nth_checked(1)?;
+                let buf = buf as usize;
+                let buf_len: u32 = args.nth_checked(2)?;
+                let buf_len = buf_len as usize;
+
+                self.memory.with_direct_access_mut(|m| {
+                    let buf = m.get_mut(buf..buf + buf_len)?;
+                    let process = &self.process.as_ref()?;
+                    process.read_buf(address, buf).ok()?;
+                    Some(())
+                });
+
+                // TODO: Possibly return error code?
+                Ok(None)
+            }
+            _ => panic!("Unimplemented function at {}", index),
+        }
+    }
+}
+
+pub struct Imports;
+
+impl ImportResolver for Imports {
+    fn resolve_func(
+        &self,
+        _module_name: &str,
+        field_name: &str,
+        _signature: &Signature,
+    ) -> Result<FuncRef, Error> {
+        let instance = match field_name {
+            "set_process_name" => FuncInstance::alloc_host(
+                Signature::new(&[ValueType::I32, ValueType::I32][..], None),
+                SET_PROCESS_NAME_FUNC_INDEX,
+            ),
+            "push_pointer_path" => FuncInstance::alloc_host(
+                Signature::new(
+                    &[ValueType::I32, ValueType::I32, ValueType::I32][..],
+                    Some(ValueType::I32),
+                ),
+                PUSH_POINTER_PATH_FUNC_INDEX,
+            ),
+            "push_offset" => FuncInstance::alloc_host(
+                Signature::new(&[ValueType::I32, ValueType::I64][..], None),
+                PUSH_OFFSET_FUNC_INDEX,
+            ),
+            "get_u8" => FuncInstance::alloc_host(
+                Signature::new(&[ValueType::I32, ValueType::I32][..], Some(ValueType::I32)),
+                GET_U8_FUNC_INDEX,
+            ),
+            "get_u16" => FuncInstance::alloc_host(
+                Signature::new(&[ValueType::I32, ValueType::I32][..], Some(ValueType::I32)),
+                GET_U16_FUNC_INDEX,
+            ),
+            "get_u32" => FuncInstance::alloc_host(
+                Signature::new(&[ValueType::I32, ValueType::I32][..], Some(ValueType::I32)),
+                GET_U32_FUNC_INDEX,
+            ),
+            "get_u64" => FuncInstance::alloc_host(
+                Signature::new(&[ValueType::I32, ValueType::I32][..], Some(ValueType::I64)),
+                GET_U64_FUNC_INDEX,
+            ),
+            "get_i8" => FuncInstance::alloc_host(
+                Signature::new(&[ValueType::I32, ValueType::I32][..], Some(ValueType::I32)),
+                GET_I8_FUNC_INDEX,
+            ),
+            "get_i16" => FuncInstance::alloc_host(
+                Signature::new(&[ValueType::I32, ValueType::I32][..], Some(ValueType::I32)),
+                GET_I16_FUNC_INDEX,
+            ),
+            "get_i32" => FuncInstance::alloc_host(
+                Signature::new(&[ValueType::I32, ValueType::I32][..], Some(ValueType::I32)),
+                GET_I32_FUNC_INDEX,
+            ),
+            "get_i64" => FuncInstance::alloc_host(
+                Signature::new(&[ValueType::I32, ValueType::I32][..], Some(ValueType::I64)),
+                GET_I64_FUNC_INDEX,
+            ),
+            "get_f32" => FuncInstance::alloc_host(
+                Signature::new(&[ValueType::I32, ValueType::I32][..], Some(ValueType::F32)),
+                GET_F32_FUNC_INDEX,
+            ),
+            "get_f64" => FuncInstance::alloc_host(
+                Signature::new(&[ValueType::I32, ValueType::I32][..], Some(ValueType::F64)),
+                GET_F64_FUNC_INDEX,
+            ),
+            "scan_signature" => FuncInstance::alloc_host(
+                Signature::new(&[ValueType::I32, ValueType::I32][..], Some(ValueType::I64)),
+                SCAN_SIGNATURE_FUNC_INDEX,
+            ),
+            "set_tick_rate" => FuncInstance::alloc_host(
+                Signature::new(&[ValueType::F64][..], None),
+                SET_TICK_RATE_FUNC_INDEX,
+            ),
+            "print_message" => FuncInstance::alloc_host(
+                Signature::new(&[ValueType::I32, ValueType::I32][..], None),
+                PRINT_MESSAGE_FUNC_INDEX,
+            ),
+            "read_into_buf" => FuncInstance::alloc_host(
+                Signature::new(&[ValueType::I64, ValueType::I32, ValueType::I32][..], None),
+                READ_INTO_BUF_FUNC_INDEX,
+            ),
+            _ => {
+                return Err(Error::Instantiation(format!(
+                    "Export {} not found",
+                    field_name
+                )));
+            }
+        };
+        Ok(instance)
+    }
+
+    fn resolve_global(
+        &self,
+        _module_name: &str,
+        _field_name: &str,
+        _descriptor: &GlobalDescriptor,
+    ) -> Result<GlobalRef, Error> {
+        Err(Error::Instantiation("Global not found".to_string()))
+    }
+    fn resolve_memory(
+        &self,
+        _module_name: &str,
+        _field_name: &str,
+        _descriptor: &MemoryDescriptor,
+    ) -> Result<MemoryRef, Error> {
+        Err(Error::Instantiation("Memory not found".to_string()))
+    }
+    fn resolve_table(
+        &self,
+        _module_name: &str,
+        _field_name: &str,
+        _descriptor: &TableDescriptor,
+    ) -> Result<TableRef, Error> {
+        Err(Error::Instantiation("Table not found".to_string()))
+    }
+}
+
+fn get_val(
+    args: RuntimeArgs,
+    pointer_paths: &[PointerPath],
+    convert: impl FnOnce(&PointerValue) -> Option<RuntimeValue>,
+) -> Result<Option<RuntimeValue>, Trap> {
+    let pointer_path_id: u32 = args.nth_checked(0)?;
+    let pointer_path_id = pointer_path_id as usize;
+    let current: bool = args.nth_checked(1)?;
+
+    let pointer_path = pointer_paths
+        .get(pointer_path_id)
+        .ok_or_else(|| EnvironmentError::InvalidPointerPathId)?;
+    let value = if current {
+        &pointer_path.current
+    } else {
+        &pointer_path.old
+    };
+    if let Some(val) = convert(value) {
+        Ok(Some(val))
+    } else {
+        Err(EnvironmentError::TypeMismatch.into())
+    }
+}

--- a/crates/livesplit-auto-splitting/src/environment.rs
+++ b/crates/livesplit-auto-splitting/src/environment.rs
@@ -139,6 +139,9 @@ impl Externals for Environment {
                 let module_name = self
                     .memory
                     .with_direct_access(|m| {
+                        if len == 0 {
+                            return Some(String::new());
+                        }
                         Some(str::from_utf8(m.get(ptr..ptr + len)?).ok()?.to_owned())
                     })
                     .ok_or_else(|| EnvironmentError::InvalidModuleName)?;

--- a/crates/livesplit-auto-splitting/src/environment.rs
+++ b/crates/livesplit-auto-splitting/src/environment.rs
@@ -238,7 +238,7 @@ impl Externals for Environment {
                 self.memory
                     .with_direct_access(|m| {
                         let message = str::from_utf8(m.get(ptr..ptr + len)?).ok()?;
-                        println!("{}", message);
+                        log::info!(target: "Auto Splitter", "{}", message);
                         Some(())
                     })
                     .ok_or_else(|| EnvironmentError::Utf8DecodeError)?;

--- a/crates/livesplit-auto-splitting/src/environment.rs
+++ b/crates/livesplit-auto-splitting/src/environment.rs
@@ -25,6 +25,7 @@ const SCAN_SIGNATURE_FUNC_INDEX: usize = 13;
 const SET_TICK_RATE_FUNC_INDEX: usize = 14;
 const PRINT_MESSAGE_FUNC_INDEX: usize = 15;
 const READ_INTO_BUF_FUNC_INDEX: usize = 16;
+const SET_VARIABLE_FUNC_INDEX: usize = 17;
 
 #[derive(Debug)]
 enum EnvironmentError {
@@ -263,6 +264,27 @@ impl Externals for Environment {
                 // TODO: Possibly return error code?
                 Ok(None)
             }
+            // SET_VARIABLE_FUNC_INDEX => {
+            //     let key_ptr: u32 = args.nth_checked(0)?;
+            //     let key_ptr = key_ptr as usize;
+            //     let key_len: u32 = args.nth_checked(1)?;
+            //     let key_len = key_len as usize;
+            //     let value_ptr: u32 = args.nth_checked(2)?;
+            //     let value_ptr = value_ptr as usize;
+            //     let value_len: u32 = args.nth_checked(3)?;
+            //     let value_len = value_len as usize;
+            //     self.memory
+            //         .with_direct_access(|m| {
+            //             let key = str::from_utf8(m.get(key_ptr..key_ptr + key_len)?).ok()?;
+            //             let value =
+            //                 str::from_utf8(m.get(value_ptr..value_ptr + value_len)?).ok()?;
+            //             log::info!(target: "Auto Splitter", "{}", message);
+            //             Some(())
+            //         })
+            //         .ok_or_else(|| EnvironmentError::Utf8DecodeError)?;
+
+            //     Ok(None)
+            // }
             _ => panic!("Unimplemented function at {}", index),
         }
     }
@@ -348,6 +370,18 @@ impl ImportResolver for Imports {
             "read_into_buf" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I64, ValueType::I32, ValueType::I32][..], None),
                 READ_INTO_BUF_FUNC_INDEX,
+            ),
+            "set_variable" => FuncInstance::alloc_host(
+                Signature::new(
+                    &[
+                        ValueType::I32,
+                        ValueType::I32,
+                        ValueType::I32,
+                        ValueType::I32,
+                    ][..],
+                    None,
+                ),
+                SET_VARIABLE_FUNC_INDEX,
             ),
             _ => {
                 return Err(Error::Instantiation(format!(

--- a/crates/livesplit-auto-splitting/src/lib.rs
+++ b/crates/livesplit-auto-splitting/src/lib.rs
@@ -1,0 +1,6 @@
+mod environment;
+mod pointer;
+mod process;
+mod runtime;
+
+pub use self::runtime::{Runtime, TimerAction, TimerState};

--- a/crates/livesplit-auto-splitting/src/lib.rs
+++ b/crates/livesplit-auto-splitting/src/lib.rs
@@ -1,4 +1,4 @@
-mod environment;
+// mod environment;
 mod pointer;
 mod process;
 mod runtime;

--- a/crates/livesplit-auto-splitting/src/pointer.rs
+++ b/crates/livesplit-auto-splitting/src/pointer.rs
@@ -1,0 +1,30 @@
+#[derive(Copy, Clone, PartialEq, Eq, num_derive::FromPrimitive)]
+#[repr(u8)]
+pub enum PointerType {
+    U8 = 0,
+    U16 = 1,
+    U32 = 2,
+    U64 = 3,
+    I8 = 4,
+    I16 = 5,
+    I32 = 6,
+    I64 = 7,
+    F32 = 8,
+    F64 = 9,
+    String = 10,
+}
+
+#[derive(Clone, Debug)]
+pub enum PointerValue {
+    U8(u8),
+    U16(u16),
+    U32(u32),
+    U64(u64),
+    I8(i8),
+    I16(i16),
+    I32(i32),
+    I64(i64),
+    F32(f32),
+    F64(f64),
+    String(String),
+}

--- a/crates/livesplit-auto-splitting/src/process.rs
+++ b/crates/livesplit-auto-splitting/src/process.rs
@@ -1,0 +1,359 @@
+use quick_error::quick_error;
+use winapi::shared::minwindef::{BOOL, DWORD};
+use winapi::um::{
+    handleapi::{CloseHandle, INVALID_HANDLE_VALUE},
+    memoryapi::{ReadProcessMemory, VirtualQueryEx},
+    processthreadsapi::{GetProcessTimes, OpenProcess},
+    tlhelp32::{
+        CreateToolhelp32Snapshot, Module32FirstW, Module32NextW, Process32FirstW, Process32NextW,
+        MODULEENTRY32W, PROCESSENTRY32W, TH32CS_SNAPMODULE, TH32CS_SNAPPROCESS,
+    },
+    winnt::{
+        HANDLE, MEMORY_BASIC_INFORMATION, MEM_COMMIT, PAGE_GUARD, PAGE_NOACCESS,
+        PROCESS_QUERY_INFORMATION, PROCESS_VM_READ,
+    },
+};
+
+use std::collections::HashMap;
+use std::ffi::OsString;
+use std::os::windows::ffi::OsStringExt;
+use std::{mem, result, slice};
+
+type Address = u64;
+pub type Offset = i64;
+
+quick_error! {
+    #[derive(Debug)]
+    pub enum Error {
+        ListProcesses {}
+        ProcessDoesntExist {}
+        ListModules {}
+        OpenProcess {}
+        ModuleDoesntExist {}
+        ReadMemory {}
+    }
+}
+
+pub type Result<T> = result::Result<T, Error>;
+
+#[derive(Debug)]
+pub struct Process {
+    handle: HANDLE,
+    modules: HashMap<String, Address>,
+    is_64bit: bool,
+}
+
+impl Drop for Process {
+    fn drop(&mut self) {
+        unsafe {
+            CloseHandle(self.handle);
+        }
+    }
+}
+
+impl Process {
+    pub fn is_64bit(&self) -> bool {
+        self.is_64bit
+    }
+
+    pub fn with_name(name: &str) -> Result<Self> {
+        unsafe {
+            let snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+
+            if snapshot == INVALID_HANDLE_VALUE {
+                return Err(Error::ListProcesses);
+            }
+
+            let mut creation_time = mem::uninitialized();
+            let mut exit_time = mem::uninitialized();
+            let mut kernel_time = mem::uninitialized();
+            let mut user_time = mem::uninitialized();
+
+            let mut best_process = None::<(DWORD, u64)>;
+            let mut entry: PROCESSENTRY32W = mem::uninitialized();
+            entry.dwSize = mem::size_of_val(&entry) as _;
+
+            if Process32FirstW(snapshot, &mut entry) != 0 {
+                loop {
+                    {
+                        let entry_name = &entry.szExeFile;
+                        let len = entry_name.iter().take_while(|&&c| c != 0).count();
+                        let entry_name = &entry_name[..len];
+                        let entry_name = &OsString::from_wide(entry_name);
+                        if entry_name == name {
+                            let pid = entry.th32ProcessID;
+                            let process = OpenProcess(PROCESS_QUERY_INFORMATION, false as _, pid);
+
+                            if !process.is_null() {
+                                let success = GetProcessTimes(
+                                    process,
+                                    &mut creation_time,
+                                    &mut exit_time,
+                                    &mut kernel_time,
+                                    &mut user_time,
+                                );
+                                if success != 0 {
+                                    let time = (creation_time.dwHighDateTime as u64) << 32
+                                        | (creation_time.dwLowDateTime as u64);
+
+                                    if best_process.map_or(true, |(_, oldest)| time > oldest) {
+                                        best_process = Some((pid, time));
+                                    }
+                                }
+
+                                CloseHandle(process);
+                            }
+                        }
+                    }
+
+                    if Process32NextW(snapshot, &mut entry) == 0 {
+                        break;
+                    }
+                }
+            }
+
+            CloseHandle(snapshot);
+
+            if let Some((pid, _)) = best_process {
+                Process::with_pid(pid)
+            } else {
+                Err(Error::ProcessDoesntExist)
+            }
+        }
+    }
+
+    pub fn with_pid(pid: DWORD) -> Result<Self> {
+        unsafe {
+            let handle = OpenProcess(PROCESS_VM_READ | PROCESS_QUERY_INFORMATION, false as _, pid);
+
+            if !handle.is_null() {
+                let snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPMODULE, pid);
+
+                if snapshot == INVALID_HANDLE_VALUE {
+                    CloseHandle(handle);
+                    return Err(Error::ListModules);
+                }
+
+                let mut modules = HashMap::new();
+                let mut entry: MODULEENTRY32W = mem::uninitialized();
+                entry.dwSize = mem::size_of_val(&entry) as _;
+
+                if Module32FirstW(snapshot, &mut entry) != 0 {
+                    loop {
+                        {
+                            let base_address = entry.modBaseAddr as Address;
+                            let name = &entry.szModule;
+                            let len = name.iter().take_while(|&&c| c != 0).count();
+                            let name = &name[..len];
+                            let name = OsString::from_wide(name).to_string_lossy().into_owned();
+                            modules.insert(name, base_address);
+                        }
+
+                        if Module32NextW(snapshot, &mut entry) == 0 {
+                            break;
+                        }
+                    }
+                }
+
+                let is_64bit;
+                #[cfg(target_pointer_width = "64")]
+                {
+                    use winapi::um::wow64apiset::IsWow64Process;
+
+                    let mut pbool: BOOL = 0;
+                    IsWow64Process(handle, &mut pbool);
+                    is_64bit = pbool == 0;
+                }
+                #[cfg(not(target_pointer_width = "64"))]
+                {
+                    // TODO Actually idk if 32-bit apps can read from 64-bit
+                    // apps. If they can, then this is wrong.
+                    is_64bit = false;
+                }
+
+                CloseHandle(snapshot);
+
+                Ok(Self {
+                    handle,
+                    modules,
+                    is_64bit,
+                })
+            } else {
+                Err(Error::OpenProcess)
+            }
+        }
+    }
+
+    pub fn module_address(&self, module: &str) -> Result<Address> {
+        self.modules
+            .get(module)
+            .cloned()
+            .ok_or(Error::ModuleDoesntExist)
+    }
+
+    pub fn read_buf(&self, address: Address, buf: &mut [u8]) -> Result<()> {
+        unsafe {
+            let mut bytes_read = mem::uninitialized();
+
+            let successful = ReadProcessMemory(
+                self.handle,
+                address as _,
+                buf.as_mut_ptr() as _,
+                buf.len() as _,
+                &mut bytes_read,
+            ) != 0;
+
+            if successful && bytes_read as usize == buf.len() {
+                Ok(())
+            } else {
+                Err(Error::ReadMemory)
+            }
+        }
+    }
+
+    pub fn read<T: Copy>(&self, address: Address) -> Result<T> {
+        // TODO Unsound af
+        unsafe {
+            let mut res = mem::uninitialized();
+            let buf = slice::from_raw_parts_mut(mem::transmute(&mut res), mem::size_of::<T>());
+            self.read_buf(address, buf).map(|_| res)
+        }
+    }
+
+    fn memory_pages(&self, all: bool) -> impl Iterator<Item = MEMORY_BASIC_INFORMATION> + '_ {
+        // hardcoded values because GetSystemInfo / GetNativeSystemInfo can't
+        // return info for remote process
+        let min = 0x10000u64;
+        let max = if self.is_64bit() {
+            0x00007FFFFFFEFFFFu64
+        } else {
+            0x7FFEFFFFu64
+        };
+
+        let mbi_size = mem::size_of::<MEMORY_BASIC_INFORMATION>();
+        let mut addr = min;
+        itertools::unfold((), move |_| {
+            while addr < max {
+                unsafe {
+                    let mut mbi: MEMORY_BASIC_INFORMATION = mem::uninitialized();
+                    if VirtualQueryEx(self.handle, addr as _, &mut mbi, mbi_size) == 0 {
+                        break;
+                    }
+                    addr += mbi.RegionSize as u64;
+
+                    // We don't care about reserved / free pages
+                    if mbi.State != MEM_COMMIT {
+                        continue;
+                    }
+
+                    // We can't read from guarded pages
+                    if !all && (mbi.Protect & PAGE_GUARD) != 0 {
+                        continue;
+                    }
+
+                    // We can't read from no access pages
+                    if !all && (mbi.Protect & PAGE_NOACCESS) != 0 {
+                        continue;
+                    }
+
+                    return Some(mbi);
+                }
+            }
+            None
+        })
+    }
+
+    pub fn scan_signature(&self, signature: &str) -> Result<Option<Address>> {
+        let signature = Signature::new(signature);
+
+        let mut page_buf = Vec::<u8>::new();
+
+        for page in self.memory_pages(false) {
+            let base = page.BaseAddress as Address;
+            let len = page.RegionSize as usize;
+            page_buf.clear();
+            page_buf.reserve(len);
+            unsafe {
+                page_buf.set_len(len);
+            }
+            self.read_buf(base, &mut page_buf)?;
+            if let Some(index) = signature.scan(&page_buf) {
+                return Ok(Some(base + index as Address));
+            }
+        }
+        Ok(None)
+    }
+}
+
+struct Signature {
+    bytes: Vec<u8>,
+    mask: Vec<bool>,
+    skip_offsets: [usize; 256],
+}
+
+impl Signature {
+    fn new(signature: &str) -> Self {
+        let mut bytes_iter = signature.bytes().filter_map(|b| match b {
+            b'0'..=b'9' => Some(b - b'0'),
+            b'a'..=b'f' => Some(b - b'a' + 0xA),
+            b'A'..=b'F' => Some(b - b'A' + 0xA),
+            b'?' => Some(0x10),
+            _ => None,
+        });
+        let (mut bytes, mut mask) = (Vec::new(), Vec::new());
+
+        while let (Some(a), Some(b)) = (bytes_iter.next(), bytes_iter.next()) {
+            let sig_byte = (a << 4) | b;
+            let is_question_marks = a == 0x10 && b == 0x10;
+            bytes.push(sig_byte);
+            mask.push(is_question_marks);
+        }
+
+        let mut skip_offsets = [0; 256];
+
+        let mut unknown = 0;
+        let end = bytes.len() - 1;
+        for (i, (&byte, mask)) in bytes.iter().zip(&mask).enumerate().take(end) {
+            if !mask {
+                skip_offsets[byte as usize] = end - i;
+            } else {
+                unknown = end - i;
+            }
+        }
+
+        if unknown == 0 {
+            unknown = bytes.len();
+        }
+
+        for offset in &mut skip_offsets[..] {
+            if unknown < *offset || *offset == 0 {
+                *offset = unknown;
+            }
+        }
+
+        Self {
+            bytes,
+            mask,
+            skip_offsets,
+        }
+    }
+
+    fn scan(&self, buf: &[u8]) -> Option<usize> {
+        let mut current = 0;
+        let end = self.bytes.len() - 1;
+        while current <= buf.len() - self.bytes.len() {
+            let rem = &buf[current..];
+            if rem
+                .iter()
+                .zip(&self.bytes)
+                .zip(&self.mask)
+                .all(|((&buf, &search), &mask)| buf == search || mask)
+            {
+                return Some(current);
+            }
+            let offset = self.skip_offsets[rem[end] as usize];
+            current += offset;
+        }
+        None
+    }
+}

--- a/crates/livesplit-auto-splitting/src/process.rs
+++ b/crates/livesplit-auto-splitting/src/process.rs
@@ -1,28 +1,31 @@
 use quick_error::quick_error;
-use winapi::shared::minwindef::{BOOL, DWORD};
-use winapi::um::{
-    handleapi::{CloseHandle, INVALID_HANDLE_VALUE},
-    memoryapi::{ReadProcessMemory, VirtualQueryEx},
-    processthreadsapi::{GetProcessTimes, OpenProcess},
-    psapi::GetModuleFileNameExW,
-    tlhelp32::{
-        CreateToolhelp32Snapshot, Module32FirstW, Module32NextW, Process32FirstW, Process32NextW,
-        MODULEENTRY32W, PROCESSENTRY32W, TH32CS_SNAPMODULE, TH32CS_SNAPPROCESS,
-    },
-    winnt::{
-        HANDLE, MEMORY_BASIC_INFORMATION, MEM_COMMIT, PAGE_GUARD, PAGE_NOACCESS,
-        PROCESS_QUERY_INFORMATION, PROCESS_VM_READ,
-    },
-};
+// use winapi::shared::minwindef::{BOOL, DWORD};
+// use winapi::um::{
+//     handleapi::{CloseHandle, INVALID_HANDLE_VALUE},
+//     memoryapi::{ReadProcessMemory, VirtualQueryEx},
+//     processthreadsapi::{GetProcessTimes, OpenProcess},
+//     psapi::GetModuleFileNameExW,
+//     tlhelp32::{
+//         CreateToolhelp32Snapshot, Module32FirstW, Module32NextW, Process32FirstW, Process32NextW,
+//         MODULEENTRY32W, PROCESSENTRY32W, TH32CS_SNAPMODULE, TH32CS_SNAPPROCESS,
+//     },
+//     winnt::{
+//         HANDLE, MEMORY_BASIC_INFORMATION, MEM_COMMIT, PAGE_GUARD, PAGE_NOACCESS,
+//         PROCESS_QUERY_INFORMATION, PROCESS_VM_READ,
+//     },
+// };
+
+use proc_maps::{get_process_maps, MapRange, Pid};
+use read_process_memory::{CopyAddress, TryIntoProcessHandle, ProcessHandle};
 
 use std::collections::HashMap;
 use std::ffi::OsString;
-use std::os::windows::ffi::OsStringExt;
+// use std::os::windows::ffi::OsStringExt;
 use std::path::PathBuf;
 use std::{mem, ptr, result, slice};
 
-type Address = u64;
-pub type Offset = i64;
+type Address = usize;
+pub type Offset = isize;
 
 quick_error! {
     #[derive(Debug)]
@@ -40,166 +43,108 @@ pub type Result<T> = result::Result<T, Error>;
 
 #[derive(Debug)]
 pub struct Process {
-    handle: HANDLE,
-    modules: HashMap<String, Address>,
-    is_64bit: bool,
-}
-
-impl Drop for Process {
-    fn drop(&mut self) {
-        unsafe {
-            CloseHandle(self.handle);
-        }
-    }
+    pid: Pid,
+    handle: ProcessHandle,
+    modules: HashMap<String, Address>
 }
 
 impl Process {
-    pub fn is_64bit(&self) -> bool {
-        self.is_64bit
-    }
-
     pub fn path(&self) -> Option<PathBuf> {
-        let mut path_buf = [0u16; 1024];
-        if unsafe {
-            GetModuleFileNameExW(
-                self.handle,
-                ptr::null_mut(),
-                path_buf.as_mut_ptr() as *mut _,
-                path_buf.len() as _,
-            )
-        } == 0
-        {
-            return None;
-        }
-        Some(PathBuf::from(OsString::from_wide(&path_buf)))
+        // let mut path_buf = [0u16; 1024];
+        // if unsafe {
+        //     GetModuleFileNameExW(
+        //         self.handle,
+        //         ptr::null_mut(),
+        //         path_buf.as_mut_ptr() as *mut _,
+        //         path_buf.len() as _,
+        //     )
+        // } == 0
+        // {
+        //     return None;
+        // }
+        // Some(PathBuf::from(OsString::from_wide(&path_buf)))
+        unimplemented!()
     }
 
     pub fn with_name(name: &str) -> Result<Self> {
-        unsafe {
-            let snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
-
-            if snapshot == INVALID_HANDLE_VALUE {
-                return Err(Error::ListProcesses);
-            }
-
-            let mut creation_time = mem::uninitialized();
-            let mut exit_time = mem::uninitialized();
-            let mut kernel_time = mem::uninitialized();
-            let mut user_time = mem::uninitialized();
-
-            let mut best_process = None::<(DWORD, u64)>;
-            let mut entry: PROCESSENTRY32W = mem::uninitialized();
-            entry.dwSize = mem::size_of_val(&entry) as _;
-
-            if Process32FirstW(snapshot, &mut entry) != 0 {
-                loop {
-                    {
-                        let entry_name = &entry.szExeFile;
-                        let len = entry_name.iter().take_while(|&&c| c != 0).count();
-                        let entry_name = &entry_name[..len];
-                        let entry_name = &OsString::from_wide(entry_name);
-                        if entry_name == name {
-                            let pid = entry.th32ProcessID;
-                            let process = OpenProcess(PROCESS_QUERY_INFORMATION, false as _, pid);
-
-                            if !process.is_null() {
-                                let success = GetProcessTimes(
-                                    process,
-                                    &mut creation_time,
-                                    &mut exit_time,
-                                    &mut kernel_time,
-                                    &mut user_time,
-                                );
-                                if success != 0 {
-                                    let time = (creation_time.dwHighDateTime as u64) << 32
-                                        | (creation_time.dwLowDateTime as u64);
-
-                                    if best_process.map_or(true, |(_, oldest)| time > oldest) {
-                                        best_process = Some((pid, time));
-                                    }
-                                }
-
-                                CloseHandle(process);
-                            }
-                        }
-                    }
-
-                    if Process32NextW(snapshot, &mut entry) == 0 {
-                        break;
-                    }
-                }
-            }
-
-            CloseHandle(snapshot);
-
-            if let Some((pid, _)) = best_process {
-                Process::with_pid(pid)
-            } else {
-                Err(Error::ProcessDoesntExist)
-            }
-        }
+        // unsafe {
+        //     let snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+        //
+        //     if snapshot == INVALID_HANDLE_VALUE {
+        //         return Err(Error::ListProcesses);
+        //     }
+        //
+        //     let mut creation_time = mem::uninitialized();
+        //     let mut exit_time = mem::uninitialized();
+        //     let mut kernel_time = mem::uninitialized();
+        //     let mut user_time = mem::uninitialized();
+        //
+        //     let mut best_process = None::<(DWORD, u64)>;
+        //     let mut entry: PROCESSENTRY32W = mem::uninitialized();
+        //     entry.dwSize = mem::size_of_val(&entry) as _;
+        //
+        //     if Process32FirstW(snapshot, &mut entry) != 0 {
+        //         loop {
+        //             {
+        //                 let entry_name = &entry.szExeFile;
+        //                 let len = entry_name.iter().take_while(|&&c| c != 0).count();
+        //                 let entry_name = &entry_name[..len];
+        //                 let entry_name = &OsString::from_wide(entry_name);
+        //                 if entry_name == name {
+        //                     let pid = entry.th32ProcessID;
+        //                     let process = OpenProcess(PROCESS_QUERY_INFORMATION, false as _, pid);
+        //
+        //                     if !process.is_null() {
+        //                         let success = GetProcessTimes(
+        //                             process,
+        //                             &mut creation_time,
+        //                             &mut exit_time,
+        //                             &mut kernel_time,
+        //                             &mut user_time,
+        //                         );
+        //                         if success != 0 {
+        //                             let time = (creation_time.dwHighDateTime as u64) << 32
+        //                                 | (creation_time.dwLowDateTime as u64);
+        //
+        //                             if best_process.map_or(true, |(_, oldest)| time > oldest) {
+        //                                 best_process = Some((pid, time));
+        //                             }
+        //                         }
+        //
+        //                         CloseHandle(process);
+        //                     }
+        //                 }
+        //             }
+        //
+        //             if Process32NextW(snapshot, &mut entry) == 0 {
+        //                 break;
+        //             }
+        //         }
+        //     }
+        //
+        //     CloseHandle(snapshot);
+        //
+        //     if let Some((pid, _)) = best_process {
+        //         Process::with_pid(pid)
+        //     } else {
+        //         Err(Error::ProcessDoesntExist)
+        //     }
+        // }
+        unimplemented!()
     }
 
-    pub fn with_pid(pid: DWORD) -> Result<Self> {
-        unsafe {
-            let handle = OpenProcess(PROCESS_VM_READ | PROCESS_QUERY_INFORMATION, false as _, pid);
+    pub fn with_pid(pid: Pid) -> Result<Self> {
+        let modules: HashMap<_,_> = get_process_maps(pid).map_err(|e| Error::ProcessDoesntExist)?
+            .into_iter().filter(|range| range.filename().is_some()).map(|range| {
+                (range.filename().clone().unwrap(), range.start())
+            }).collect();
+        let handle = (pid as read_process_memory::Pid).try_into_process_handle().map_err(|e| Error::ProcessDoesntExist)?;
 
-            if !handle.is_null() {
-                let snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPMODULE, pid);
-
-                if snapshot == INVALID_HANDLE_VALUE {
-                    CloseHandle(handle);
-                    return Err(Error::ListModules);
-                }
-
-                let mut modules = HashMap::new();
-                let mut entry: MODULEENTRY32W = mem::uninitialized();
-                entry.dwSize = mem::size_of_val(&entry) as _;
-
-                if Module32FirstW(snapshot, &mut entry) != 0 {
-                    loop {
-                        {
-                            let base_address = entry.modBaseAddr as Address;
-                            let name = &entry.szModule;
-                            let len = name.iter().take_while(|&&c| c != 0).count();
-                            let name = &name[..len];
-                            let name = OsString::from_wide(name).to_string_lossy().into_owned();
-                            modules.insert(name, base_address);
-                        }
-
-                        if Module32NextW(snapshot, &mut entry) == 0 {
-                            break;
-                        }
-                    }
-                }
-
-                let is_64bit;
-                #[cfg(target_pointer_width = "64")]
-                {
-                    use winapi::um::wow64apiset::IsWow64Process;
-
-                    let mut pbool: BOOL = 0;
-                    IsWow64Process(handle, &mut pbool);
-                    is_64bit = pbool == 0;
-                }
-                #[cfg(not(target_pointer_width = "64"))]
-                {
-                    // TODO Actually idk if 32-bit apps can read from 64-bit
-                    // apps. If they can, then this is wrong.
-                    is_64bit = false;
-                }
-
-                CloseHandle(snapshot);
-
-                Ok(Self {
-                    handle,
-                    modules,
-                    is_64bit,
-                })
-            } else {
-                Err(Error::OpenProcess)
-            }
-        }
+        Ok(Self {
+            pid,
+            handle,
+            modules
+        })
     }
 
     pub fn module_address(&self, module: &str) -> Result<Address> {
@@ -210,23 +155,7 @@ impl Process {
     }
 
     pub fn read_buf(&self, address: Address, buf: &mut [u8]) -> Result<()> {
-        unsafe {
-            let mut bytes_read = mem::uninitialized();
-
-            let successful = ReadProcessMemory(
-                self.handle,
-                address as _,
-                buf.as_mut_ptr() as _,
-                buf.len() as _,
-                &mut bytes_read,
-            ) != 0;
-
-            if successful && bytes_read as usize == buf.len() {
-                Ok(())
-            } else {
-                Err(Error::ReadMemory)
-            }
-        }
+        self.handle.copy_address(address, buf).map_err(|_| Error::ReadMemory)
     }
 
     pub fn read<T: Copy>(&self, address: Address) -> Result<T> {
@@ -238,47 +167,9 @@ impl Process {
         }
     }
 
-    fn memory_pages(&self, all: bool) -> impl Iterator<Item = MEMORY_BASIC_INFORMATION> + '_ {
-        // hardcoded values because GetSystemInfo / GetNativeSystemInfo can't
-        // return info for remote process
-        let min = 0x10000u64;
-        let max = if self.is_64bit() {
-            0x00007FFFFFFEFFFFu64
-        } else {
-            0x7FFEFFFFu64
-        };
-
-        let mbi_size = mem::size_of::<MEMORY_BASIC_INFORMATION>();
-        let mut addr = min;
-        itertools::unfold((), move |_| {
-            while addr < max {
-                unsafe {
-                    let mut mbi: MEMORY_BASIC_INFORMATION = mem::uninitialized();
-                    if VirtualQueryEx(self.handle, addr as _, &mut mbi, mbi_size) == 0 {
-                        break;
-                    }
-                    addr += mbi.RegionSize as u64;
-
-                    // We don't care about reserved / free pages
-                    if mbi.State != MEM_COMMIT {
-                        continue;
-                    }
-
-                    // We can't read from guarded pages
-                    if !all && (mbi.Protect & PAGE_GUARD) != 0 {
-                        continue;
-                    }
-
-                    // We can't read from no access pages
-                    if !all && (mbi.Protect & PAGE_NOACCESS) != 0 {
-                        continue;
-                    }
-
-                    return Some(mbi);
-                }
-            }
-            None
-        })
+    fn memory_pages(&self, all: bool) -> Result<impl Iterator<Item = MapRange> + '_> {
+        Ok(get_process_maps(self.pid).map_err(|e| Error::ProcessDoesntExist)?
+            .into_iter().filter(move |range| all || range.is_read()))
     }
 
     pub fn scan_signature(&self, signature: &str) -> Result<Option<Address>> {
@@ -286,9 +177,9 @@ impl Process {
 
         let mut page_buf = Vec::<u8>::new();
 
-        for page in self.memory_pages(false) {
-            let base = page.BaseAddress as Address;
-            let len = page.RegionSize as usize;
+        for page in self.memory_pages(false)? {
+            let base = page.start();
+            let len = page.size();
             page_buf.clear();
             page_buf.reserve(len);
             unsafe {

--- a/crates/livesplit-auto-splitting/src/runtime.rs
+++ b/crates/livesplit-auto-splitting/src/runtime.rs
@@ -98,13 +98,13 @@ impl Runtime {
                 Ok(p) => Some(p),
                 Err(_) => return Ok(None),
             };
-            eprintln!("Connected");
+            log::info!(target: "Auto Splitter", "Hooked");
             just_connected = true;
         }
 
         if self.update_values(just_connected).is_err() {
             // TODO: Only checks for disconnected if we actually have pointer paths
-            eprintln!("Disconnected");
+            log::info!(target: "Auto Splitter", "Unhooked");
             self.environment.process = None;
             if let Some(func) = &self.disconnected {
                 FuncInstance::invoke(func, &[], &mut self.environment)?;

--- a/crates/livesplit-auto-splitting/src/runtime.rs
+++ b/crates/livesplit-auto-splitting/src/runtime.rs
@@ -200,7 +200,14 @@ impl Runtime {
                     let ret_val = FuncInstance::invoke(func, &[], &mut self.environment)?;
 
                     self.game_time_val = match ret_val {
-                        Some(RuntimeValue::F64(val)) => Some(val.to_float()),
+                        Some(RuntimeValue::F64(val)) => {
+                            let val = val.to_float();
+                            if val.is_nan() {
+                                None
+                            } else {
+                                Some(val)
+                            }
+                        }
                         _ => None,
                     };
                 }

--- a/crates/livesplit-auto-splitting/src/runtime.rs
+++ b/crates/livesplit-auto-splitting/src/runtime.rs
@@ -1,0 +1,195 @@
+use crate::environment::{Environment, Imports};
+use crate::pointer::PointerValue;
+use crate::process::{Offset, Process};
+use std::{error::Error, mem, thread};
+use wasmi::{
+    ExternVal, FuncInstance, FuncRef, MemoryRef, Module, ModuleInstance, ModuleRef, RuntimeValue,
+};
+
+pub struct Runtime {
+    _instance: ModuleRef,
+    environment: Environment,
+    timer_state: TimerState,
+    should_start: Option<FuncRef>,
+    should_split: Option<FuncRef>,
+    should_reset: Option<FuncRef>,
+    update: Option<FuncRef>,
+}
+
+#[repr(u8)]
+pub enum TimerState {
+    NotRunning = 0,
+    Running = 1,
+    Paused = 2,
+    Finished = 3,
+}
+
+#[derive(Debug)]
+pub enum TimerAction {
+    Start,
+    Split,
+    Reset,
+}
+
+impl Runtime {
+    pub fn new(binary: &[u8]) -> Result<Self, Box<Error>> {
+        let module = Module::from_buffer(binary)?;
+        let instance = ModuleInstance::new(&module, &Imports)?;
+        let memory = into_memory(
+            instance
+                .not_started_instance()
+                .export_by_name("memory")
+                .ok_or("memory not exported")?,
+        )?;
+        let mut environment = Environment::new(memory);
+        let instance = instance.run_start(&mut environment)?;
+        instance.invoke_export("configure", &[], &mut environment)?;
+
+        let should_start = instance
+            .export_by_name("should_start")
+            .and_then(|e| e.as_func()?.clone().into());
+        let should_split = instance
+            .export_by_name("should_split")
+            .and_then(|e| e.as_func()?.clone().into());
+        let should_reset = instance
+            .export_by_name("should_reset")
+            .and_then(|e| e.as_func()?.clone().into());
+        let update = instance
+            .export_by_name("update")
+            .and_then(|e| e.as_func()?.clone().into());
+
+        Ok(Self {
+            _instance: instance,
+            environment,
+            timer_state: TimerState::NotRunning,
+            should_start,
+            should_split,
+            should_reset,
+            update,
+        })
+    }
+
+    pub fn sleep(&self) {
+        thread::sleep(self.environment.tick_rate);
+    }
+
+    pub fn step(&mut self) -> Result<Option<TimerAction>, Box<Error>> {
+        let mut just_connected = false;
+        if self.environment.process.is_none() {
+            self.environment.process = match Process::with_name(&self.environment.process_name) {
+                Ok(p) => Some(p),
+                Err(_) => return Ok(None),
+            };
+            eprintln!("Connected");
+            just_connected = true;
+        }
+
+        if self.update_values(just_connected).is_err() {
+            eprintln!("Disconnected");
+            self.environment.process = None;
+            return Ok(None);
+        }
+        // println!("{:#?}", self.environment);
+        self.run_script()
+    }
+
+    pub fn set_state(&mut self, state: TimerState) {
+        self.timer_state = state;
+    }
+
+    fn update_values(&mut self, just_connected: bool) -> Result<(), Box<Error>> {
+        let process = self
+            .environment
+            .process
+            .as_mut()
+            .expect("The process should be connected at this point");
+
+        for pointer_path in &mut self.environment.pointer_paths {
+            let mut address = process.module_address(&pointer_path.module_name)?;
+            let mut offsets = pointer_path.offsets.iter().cloned().peekable();
+            if process.is_64bit() {
+                while let Some(offset) = offsets.next() {
+                    address = (address as Offset).wrapping_add(offset) as u64;
+                    if offsets.peek().is_some() {
+                        address = process.read(address)?;
+                    }
+                }
+            } else {
+                while let Some(offset) = offsets.next() {
+                    address = (address as i32).wrapping_add(offset as i32) as u64;
+                    if offsets.peek().is_some() {
+                        address = process.read::<u32>(address)? as u64;
+                    }
+                }
+            }
+            match &mut pointer_path.old {
+                PointerValue::U8(v) => *v = process.read(address)?,
+                PointerValue::U16(v) => *v = process.read(address)?,
+                PointerValue::U32(v) => *v = process.read(address)?,
+                PointerValue::U64(v) => *v = process.read(address)?,
+                PointerValue::I8(v) => *v = process.read(address)?,
+                PointerValue::I16(v) => *v = process.read(address)?,
+                PointerValue::I32(v) => *v = process.read(address)?,
+                PointerValue::I64(v) => *v = process.read(address)?,
+                PointerValue::F32(v) => *v = process.read(address)?,
+                PointerValue::F64(v) => *v = process.read(address)?,
+                PointerValue::String(_) => unimplemented!(),
+            }
+        }
+
+        if just_connected {
+            for pointer_path in &mut self.environment.pointer_paths {
+                pointer_path.current.clone_from(&pointer_path.old);
+            }
+        } else {
+            for pointer_path in &mut self.environment.pointer_paths {
+                mem::swap(&mut pointer_path.current, &mut pointer_path.old);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn run_script(&mut self) -> Result<Option<TimerAction>, Box<Error>> {
+        if let Some(func) = &self.update {
+            FuncInstance::invoke(func, &[], &mut self.environment)?;
+        }
+
+        match &self.timer_state {
+            TimerState::NotRunning => {
+                if let Some(func) = &self.should_start {
+                    let ret_val = FuncInstance::invoke(func, &[], &mut self.environment)?;
+
+                    if let Some(RuntimeValue::I32(1)) = ret_val {
+                        return Ok(Some(TimerAction::Start));
+                    }
+                }
+            }
+            TimerState::Running => {
+                if let Some(func) = &self.should_split {
+                    let ret_val = FuncInstance::invoke(func, &[], &mut self.environment)?;
+
+                    if let Some(RuntimeValue::I32(1)) = ret_val {
+                        return Ok(Some(TimerAction::Split));
+                    }
+                }
+                if let Some(func) = &self.should_reset {
+                    let ret_val = FuncInstance::invoke(func, &[], &mut self.environment)?;
+
+                    if let Some(RuntimeValue::I32(1)) = ret_val {
+                        return Ok(Some(TimerAction::Reset));
+                    }
+                }
+            }
+            _ => unimplemented!(),
+        }
+        Ok(None)
+    }
+}
+
+fn into_memory(extern_val: ExternVal) -> Result<MemoryRef, Box<Error>> {
+    match extern_val {
+        ExternVal::Memory(memory) => Ok(memory),
+        _ => Err("Memory is not exported correctly".into()),
+    }
+}

--- a/crates/livesplit-auto-splitting/src/runtime.rs
+++ b/crates/livesplit-auto-splitting/src/runtime.rs
@@ -127,7 +127,11 @@ impl Runtime {
             .expect("The process should be connected at this point");
 
         for pointer_path in &mut self.environment.pointer_paths {
-            let mut address = process.module_address(&pointer_path.module_name)?;
+            let mut address = if !pointer_path.module_name.is_empty() {
+                process.module_address(&pointer_path.module_name)?
+            } else {
+                0
+            };
             let mut offsets = pointer_path.offsets.iter().cloned().peekable();
             if process.is_64bit() {
                 while let Some(offset) = offsets.next() {

--- a/crates/livesplit-auto-splitting/src/runtime.rs
+++ b/crates/livesplit-auto-splitting/src/runtime.rs
@@ -1,22 +1,23 @@
-use crate::environment::{Environment, Imports};
+// use crate::environment::{Environment, Imports};
 use crate::pointer::PointerValue;
 use crate::process::{Offset, Process};
-use std::{error::Error, mem, thread};
-use wasmi::{
-    ExternVal, FuncInstance, FuncRef, MemoryRef, Module, ModuleInstance, ModuleRef, RuntimeValue,
-};
+use std::{error::Error, mem, str, thread, time::Duration};
+// use wasmi::{
+//     ExternVal, FuncInstance, FuncRef, MemoryRef, Module, ModuleInstance, ModuleRef, RuntimeValue,
+// };
+use wasmer_runtime::{func, imports, memory::MemoryView, Ctx, Func, Instance};
 
 pub struct Runtime {
-    _instance: ModuleRef,
+    instance: Instance,
     environment: Environment,
     timer_state: TimerState,
-    should_start: Option<FuncRef>,
-    should_split: Option<FuncRef>,
-    should_reset: Option<FuncRef>,
-    is_loading: Option<FuncRef>,
-    game_time: Option<FuncRef>,
-    update: Option<FuncRef>,
-    disconnected: Option<FuncRef>,
+    // should_start: Option<FuncRef>,
+    // should_split: Option<FuncRef>,
+    // should_reset: Option<FuncRef>,
+    // is_loading: Option<FuncRef>,
+    // game_time: Option<FuncRef>,
+    // update: Option<FuncRef>,
+    // disconnected: Option<FuncRef>,
     is_loading_val: Option<bool>,
     game_time_val: Option<f64>,
 }
@@ -35,53 +36,108 @@ pub enum TimerAction {
     Reset,
 }
 
+#[derive(Debug)]
+enum EnvironmentError {
+    InvalidProcessName,
+    InvalidModuleName,
+    InvalidPointerPathId,
+    InvalidPointerType,
+    TypeMismatch,
+    Utf8DecodeError,
+}
+
+pub struct Environment {
+    pub process_name: String,
+    // TODO Undo pub
+    pub pointer_paths: Vec<PointerPath>,
+    pub tick_rate: Duration,
+    pub process: Option<Process>,
+}
+
+#[derive(Debug)]
+pub struct PointerPath {
+    pub module_name: String,
+    pub offsets: Vec<i64>,
+    // TODO Undo pub
+    pub current: PointerValue,
+    pub old: PointerValue,
+}
+
+impl Environment {
+    pub fn new() -> Self {
+        Self {
+            process_name: String::new(),
+            pointer_paths: Vec::new(),
+            tick_rate: Duration::from_secs(1) / 60,
+            process: None,
+        }
+    }
+}
+
 impl Runtime {
     pub fn new(binary: &[u8]) -> Result<Self, Box<Error>> {
-        let module = Module::from_buffer(binary)?;
-        let instance = ModuleInstance::new(&module, &Imports)?;
-        let memory = into_memory(
-            instance
-                .not_started_instance()
-                .export_by_name("memory")
-                .ok_or("memory not exported")?,
-        )?;
-        let mut environment = Environment::new(memory);
-        let instance = instance.run_start(&mut environment)?;
-        instance.invoke_export("configure", &[], &mut environment)?;
+        let import_object = imports! {
+            "env" => {
+                "set_process_name" => func!(set_process_name),
+                "push_pointer_path" => func!(push_pointer_path),
+                "push_offset" => func!(push_offset),
+                "get_u8" => func!(get_u8),
+                "get_u16" => func!(get_u16),
+                "get_u32" => func!(get_u32),
+                "get_u64" => func!(get_u64),
+                "get_i8" => func!(get_i8),
+                "get_i16" => func!(get_i16),
+                "get_i32" => func!(get_i32),
+                "get_i64" => func!(get_i64),
+                "get_f32" => func!(get_f32),
+                "get_f64" => func!(get_f64),
+                "scan_signature" => func!(scan_signature),
+                "set_tick_rate" => func!(set_tick_rate),
+                "print_message" => func!(print_message),
+                "read_into_buf" => func!(read_into_buf),
+            },
+        };
+        let mut instance = wasmer_runtime::instantiate(binary, &import_object).unwrap();
 
-        let should_start = instance
-            .export_by_name("should_start")
-            .and_then(|e| e.as_func()?.clone().into());
-        let should_split = instance
-            .export_by_name("should_split")
-            .and_then(|e| e.as_func()?.clone().into());
-        let should_reset = instance
-            .export_by_name("should_reset")
-            .and_then(|e| e.as_func()?.clone().into());
-        let is_loading = instance
-            .export_by_name("is_loading")
-            .and_then(|e| e.as_func()?.clone().into());
-        let game_time = instance
-            .export_by_name("game_time")
-            .and_then(|e| e.as_func()?.clone().into());
-        let update = instance
-            .export_by_name("update")
-            .and_then(|e| e.as_func()?.clone().into());
-        let disconnected = instance
-            .export_by_name("disconnected")
-            .and_then(|e| e.as_func()?.clone().into());
+        let mut environment = Environment::new();
+        instance.context_mut().data = &mut environment as *mut Environment as *mut _;
+        instance
+            .call("configure", &[])
+            .map_err(|_| "Failed to run configure function")?;
+
+        // let should_start = instance
+        //     .export_by_name("should_start")
+        //     .and_then(|e| e.as_func()?.clone().into());
+        // let should_split = instance
+        //     .export_by_name("should_split")
+        //     .and_then(|e| e.as_func()?.clone().into());
+        // let should_reset = instance
+        //     .export_by_name("should_reset")
+        //     .and_then(|e| e.as_func()?.clone().into());
+        // let is_loading = instance
+        //     .export_by_name("is_loading")
+        //     .and_then(|e| e.as_func()?.clone().into());
+        // let game_time = instance
+        //     .export_by_name("game_time")
+        //     .and_then(|e| e.as_func()?.clone().into());
+        // let update = instance
+        //     .export_by_name("update")
+        //     .and_then(|e| e.as_func()?.clone().into());
+        // let disconnected = instance
+        //     .export_by_name("disconnected")
+        //     .and_then(|e| e.as_func()?.clone().into());
 
         Ok(Self {
-            _instance: instance,
+            instance,
             environment,
             timer_state: TimerState::NotRunning,
-            should_start,
-            should_split,
-            should_reset,
-            is_loading,
-            game_time,
-            update,
-            disconnected,
+            // should_start,
+            // should_split,
+            // should_reset,
+            // is_loading,
+            // game_time,
+            // update,
+            // disconnected,
             is_loading_val: None,
             game_time_val: None,
         })
@@ -106,9 +162,9 @@ impl Runtime {
             // TODO: Only checks for disconnected if we actually have pointer paths
             log::info!(target: "Auto Splitter", "Unhooked");
             self.environment.process = None;
-            if let Some(func) = &self.disconnected {
-                FuncInstance::invoke(func, &[], &mut self.environment)?;
-            }
+            // if let Some(func) = &self.disconnected {
+            //     FuncInstance::invoke(func, &[], &mut self.environment)?;
+            // }
             return Ok(None);
         }
         // println!("{:#?}", self.environment);
@@ -120,122 +176,116 @@ impl Runtime {
     }
 
     fn update_values(&mut self, just_connected: bool) -> Result<(), Box<Error>> {
-        let process = self
-            .environment
-            .process
-            .as_mut()
-            .expect("The process should be connected at this point");
+        // let process = self
+        //     .environment
+        //     .process
+        //     .as_mut()
+        //     .expect("The process should be connected at this point");
 
-        for pointer_path in &mut self.environment.pointer_paths {
-            let mut address = if !pointer_path.module_name.is_empty() {
-                process.module_address(&pointer_path.module_name)?
-            } else {
-                0
-            };
-            let mut offsets = pointer_path.offsets.iter().cloned().peekable();
-            if process.is_64bit() {
-                while let Some(offset) = offsets.next() {
-                    address = (address as Offset).wrapping_add(offset) as u64;
-                    if offsets.peek().is_some() {
-                        address = process.read(address)?;
-                    }
-                }
-            } else {
-                while let Some(offset) = offsets.next() {
-                    address = (address as i32).wrapping_add(offset as i32) as u64;
-                    if offsets.peek().is_some() {
-                        address = process.read::<u32>(address)? as u64;
-                    }
-                }
-            }
-            match &mut pointer_path.old {
-                PointerValue::U8(v) => *v = process.read(address)?,
-                PointerValue::U16(v) => *v = process.read(address)?,
-                PointerValue::U32(v) => *v = process.read(address)?,
-                PointerValue::U64(v) => *v = process.read(address)?,
-                PointerValue::I8(v) => *v = process.read(address)?,
-                PointerValue::I16(v) => *v = process.read(address)?,
-                PointerValue::I32(v) => *v = process.read(address)?,
-                PointerValue::I64(v) => *v = process.read(address)?,
-                PointerValue::F32(v) => *v = process.read(address)?,
-                PointerValue::F64(v) => *v = process.read(address)?,
-                PointerValue::String(_) => unimplemented!(),
-            }
-        }
+        // for pointer_path in &mut self.environment.pointer_paths {
+        //     let mut address = if !pointer_path.module_name.is_empty() {
+        //         process.module_address(&pointer_path.module_name)?
+        //     } else {
+        //         0
+        //     };
+        //     let mut offsets = pointer_path.offsets.iter().cloned().peekable();
+        //     if process.is_64bit() {
+        //         while let Some(offset) = offsets.next() {
+        //             address = (address as Offset).wrapping_add(offset) as u64;
+        //             if offsets.peek().is_some() {
+        //                 address = process.read(address)?;
+        //             }
+        //         }
+        //     } else {
+        //         while let Some(offset) = offsets.next() {
+        //             address = (address as i32).wrapping_add(offset as i32) as u64;
+        //             if offsets.peek().is_some() {
+        //                 address = process.read::<u32>(address)? as u64;
+        //             }
+        //         }
+        //     }
+        //     match &mut pointer_path.old {
+        //         PointerValue::U8(v) => *v = process.read(address)?,
+        //         PointerValue::U16(v) => *v = process.read(address)?,
+        //         PointerValue::U32(v) => *v = process.read(address)?,
+        //         PointerValue::U64(v) => *v = process.read(address)?,
+        //         PointerValue::I8(v) => *v = process.read(address)?,
+        //         PointerValue::I16(v) => *v = process.read(address)?,
+        //         PointerValue::I32(v) => *v = process.read(address)?,
+        //         PointerValue::I64(v) => *v = process.read(address)?,
+        //         PointerValue::F32(v) => *v = process.read(address)?,
+        //         PointerValue::F64(v) => *v = process.read(address)?,
+        //         PointerValue::String(_) => unimplemented!(),
+        //     }
+        // }
 
-        if just_connected {
-            for pointer_path in &mut self.environment.pointer_paths {
-                pointer_path.current.clone_from(&pointer_path.old);
-            }
-        } else {
-            for pointer_path in &mut self.environment.pointer_paths {
-                mem::swap(&mut pointer_path.current, &mut pointer_path.old);
-            }
-        }
+        // if just_connected {
+        //     for pointer_path in &mut self.environment.pointer_paths {
+        //         pointer_path.current.clone_from(&pointer_path.old);
+        //     }
+        // } else {
+        //     for pointer_path in &mut self.environment.pointer_paths {
+        //         mem::swap(&mut pointer_path.current, &mut pointer_path.old);
+        //     }
+        // }
 
         Ok(())
     }
 
     fn run_script(&mut self) -> Result<Option<TimerAction>, Box<Error>> {
-        if let Some(func) = &self.update {
-            FuncInstance::invoke(func, &[], &mut self.environment)?;
+        self.instance.context_mut().data = &mut self.environment as *mut Environment as *mut _;
+
+        if let Ok(func) = self.instance.func::<(), ()>("update") {
+            // TODO: Don't panic
+            func.call().unwrap();
         }
 
         match &self.timer_state {
             TimerState::NotRunning => {
-                if let Some(func) = &self.should_start {
-                    let ret_val = FuncInstance::invoke(func, &[], &mut self.environment)?;
+                if let Ok(func) = self.instance.func::<(), i32>("should_start") {
+                    let ret_val = func.call().unwrap();
 
-                    if let Some(RuntimeValue::I32(1)) = ret_val {
+                    if ret_val != 0 {
                         return Ok(Some(TimerAction::Start));
                     }
                 }
             }
             TimerState::Running => {
-                if let Some(func) = &self.is_loading {
-                    let ret_val = FuncInstance::invoke(func, &[], &mut self.environment)?;
+                if let Ok(func) = self.instance.func::<(), i32>("is_loading") {
+                    let ret_val = func.call().unwrap();
 
-                    self.is_loading_val = match ret_val {
-                        Some(RuntimeValue::I32(val)) => Some(val != 0),
-                        _ => None,
-                    };
+                    self.is_loading_val = Some(ret_val != 0);
                 }
-                if let Some(func) = &self.game_time {
-                    let ret_val = FuncInstance::invoke(func, &[], &mut self.environment)?;
+                if let Ok(func) = self.instance.func::<(), f64>("game_time") {
+                    let ret_val = func.call().unwrap();
 
-                    self.game_time_val = match ret_val {
-                        Some(RuntimeValue::F64(val)) => {
-                            let val = val.to_float();
-                            if val.is_nan() {
-                                None
-                            } else {
-                                Some(val)
-                            }
-                        }
-                        _ => None,
+                    self.game_time_val = if ret_val.is_nan() {
+                        None
+                    } else {
+                        Some(ret_val)
                     };
                 }
 
-                if let Some(func) = &self.should_split {
-                    let ret_val = FuncInstance::invoke(func, &[], &mut self.environment)?;
+                if let Ok(func) = self.instance.func::<(), i32>("should_split") {
+                    let ret_val = func.call().unwrap();
 
-                    if let Some(RuntimeValue::I32(1)) = ret_val {
+                    if ret_val != 0 {
                         return Ok(Some(TimerAction::Split));
                     }
                 }
-                if let Some(func) = &self.should_reset {
-                    let ret_val = FuncInstance::invoke(func, &[], &mut self.environment)?;
+                if let Ok(func) = self.instance.func::<(), i32>("should_reset") {
+                    let ret_val = func.call().unwrap();
 
-                    if let Some(RuntimeValue::I32(1)) = ret_val {
+                    if ret_val != 0 {
                         return Ok(Some(TimerAction::Reset));
                     }
                 }
             }
             TimerState::Finished => {
-                if let Some(func) = &self.should_reset {
-                    let ret_val = FuncInstance::invoke(func, &[], &mut self.environment)?;
+                if let Ok(func) = self.instance.func::<(), i32>("should_reset") {
+                    let ret_val = func.call().unwrap();
 
-                    if let Some(RuntimeValue::I32(1)) = ret_val {
+                    if ret_val != 0 {
                         return Ok(Some(TimerAction::Reset));
                     }
                 }
@@ -254,9 +304,229 @@ impl Runtime {
     }
 }
 
-fn into_memory(extern_val: ExternVal) -> Result<MemoryRef, Box<Error>> {
-    match extern_val {
-        ExternVal::Memory(memory) => Ok(memory),
-        _ => Err("Memory is not exported correctly".into()),
+fn read_bytes(memory: &MemoryView<u8>, ptr: usize, len: usize) -> Vec<u8> {
+    memory[ptr..][..len].iter().map(|c| c.get()).collect()
+}
+
+fn read_string(memory: &MemoryView<u8>, ptr: usize, len: usize) -> String {
+    // TODO: Don't panic
+    String::from_utf8(read_bytes(memory, ptr, len)).unwrap()
+}
+
+fn print_message(ctx: &mut Ctx, ptr: u32, len: u32) {
+    let ptr = ptr as usize;
+    let len = len as usize;
+    let memory = ctx.memory(0).view();
+    let message = read_string(&memory, ptr, len);
+    log::info!(target: "Auto Splitter", "{}", message);
+}
+
+fn set_process_name(ctx: &mut Ctx, ptr: u32, len: u32) {
+    let ptr = ptr as usize;
+    let len = len as usize;
+    let memory = ctx.memory(0).view();
+    let env = unsafe { &mut *(ctx.data as *mut Environment) };
+
+    env.process_name = read_string(&memory, ptr, len);
+}
+
+fn push_pointer_path(ctx: &mut Ctx, ptr: u32, len: u32, pointer_type: u32) -> u32 {
+    use crate::pointer::{PointerType, PointerValue};
+    use num_traits::FromPrimitive;
+
+    let ptr = ptr as usize;
+    let len = len as usize;
+    let memory = ctx.memory(0).view();
+    let env = unsafe { &mut *(ctx.data as *mut Environment) };
+
+    let pointer_type = PointerType::from_u8(pointer_type as u8)
+        .ok_or_else(|| EnvironmentError::InvalidPointerType)
+        .unwrap();
+    let current = match pointer_type {
+        PointerType::U8 => PointerValue::U8(0),
+        PointerType::U16 => PointerValue::U16(0),
+        PointerType::U32 => PointerValue::U32(0),
+        PointerType::U64 => PointerValue::U64(0),
+        PointerType::I8 => PointerValue::I8(0),
+        PointerType::I16 => PointerValue::I16(0),
+        PointerType::I32 => PointerValue::I32(0),
+        PointerType::I64 => PointerValue::I64(0),
+        PointerType::F32 => PointerValue::F32(0.0),
+        PointerType::F64 => PointerValue::F64(0.0),
+        PointerType::String => PointerValue::String(String::new()),
+    };
+
+    let module_name = read_string(&memory, ptr, len);
+
+    let id = env.pointer_paths.len();
+    env.pointer_paths.push(PointerPath {
+        module_name,
+        offsets: Vec::new(),
+        old: current.clone(),
+        current,
+    });
+
+    id as _
+}
+
+fn push_offset(ctx: &mut Ctx, pointer_path_id: u32, offset: i64) {
+    let pointer_path_id = pointer_path_id as usize;
+    let env = unsafe { &mut *(ctx.data as *mut Environment) };
+
+    let pointer_path = env
+        .pointer_paths
+        .get_mut(pointer_path_id)
+        .ok_or_else(|| EnvironmentError::InvalidPointerPathId)
+        .unwrap();
+    pointer_path.offsets.push(offset);
+}
+
+fn get_u8(ctx: &mut Ctx, pointer_path_id: u32, current: i32) -> u32 {
+    get_val(pointer_path_id, current, ctx, |v| match *v {
+        PointerValue::U8(v) => Some(v as _),
+        _ => None,
+    })
+    .unwrap()
+}
+
+fn get_u16(ctx: &mut Ctx, pointer_path_id: u32, current: i32) -> u32 {
+    get_val(pointer_path_id, current, ctx, |v| match *v {
+        PointerValue::U16(v) => Some(v as _),
+        _ => None,
+    })
+    .unwrap()
+}
+
+fn get_u32(ctx: &mut Ctx, pointer_path_id: u32, current: i32) -> u32 {
+    get_val(pointer_path_id, current, ctx, |v| match *v {
+        PointerValue::U32(v) => Some(v as _),
+        _ => None,
+    })
+    .unwrap()
+}
+
+fn get_u64(ctx: &mut Ctx, pointer_path_id: u32, current: i32) -> u64 {
+    get_val(pointer_path_id, current, ctx, |v| match *v {
+        PointerValue::U64(v) => Some(v as _),
+        _ => None,
+    })
+    .unwrap()
+}
+
+fn get_i8(ctx: &mut Ctx, pointer_path_id: u32, current: i32) -> i32 {
+    get_val(pointer_path_id, current, ctx, |v| match *v {
+        PointerValue::I8(v) => Some(v as _),
+        _ => None,
+    })
+    .unwrap()
+}
+
+fn get_i16(ctx: &mut Ctx, pointer_path_id: u32, current: i32) -> i32 {
+    get_val(pointer_path_id, current, ctx, |v| match *v {
+        PointerValue::I16(v) => Some(v as _),
+        _ => None,
+    })
+    .unwrap()
+}
+
+fn get_i32(ctx: &mut Ctx, pointer_path_id: u32, current: i32) -> i32 {
+    get_val(pointer_path_id, current, ctx, |v| match *v {
+        PointerValue::I32(v) => Some(v as _),
+        _ => None,
+    })
+    .unwrap()
+}
+
+fn get_i64(ctx: &mut Ctx, pointer_path_id: u32, current: i32) -> i64 {
+    get_val(pointer_path_id, current, ctx, |v| match *v {
+        PointerValue::I64(v) => Some(v as _),
+        _ => None,
+    })
+    .unwrap()
+}
+
+fn get_f32(ctx: &mut Ctx, pointer_path_id: u32, current: i32) -> f32 {
+    get_val(pointer_path_id, current, ctx, |v| match *v {
+        PointerValue::F32(v) => Some(v as _),
+        _ => None,
+    })
+    .unwrap()
+}
+
+fn get_f64(ctx: &mut Ctx, pointer_path_id: u32, current: i32) -> f64 {
+    get_val(pointer_path_id, current, ctx, |v| match *v {
+        PointerValue::F64(v) => Some(v as _),
+        _ => None,
+    })
+    .unwrap()
+}
+
+fn scan_signature(ctx: &mut Ctx, ptr: u32, len: u32) -> u64 {
+    let ptr = ptr as usize;
+    let len = len as usize;
+    let memory = ctx.memory(0).view();
+    let env = unsafe { &mut *(ctx.data as *mut Environment) };
+
+    // TODO: Don't panic
+    if let Some(process) = &env.process {
+        let signature = read_string(&memory, ptr, len);
+        let address = process.scan_signature(&signature).unwrap();
+        return address.unwrap_or(0);
+    }
+
+    0
+}
+
+fn set_tick_rate(ctx: &mut Ctx, ticks_per_sec: f64) {
+    log::info!("New Tick Rate: {:?}", ticks_per_sec);
+    let env = unsafe { &mut *(ctx.data as *mut Environment) };
+    env.tick_rate = Duration::from_nanos((1_000_000_000.0 / ticks_per_sec).round() as u64);
+}
+
+fn read_into_buf(ctx: &mut Ctx, address: u64, buf: u32, buf_len: u32) {
+    let buf = buf as usize;
+    let buf_len = buf_len as usize;
+    let env = unsafe { &mut *(ctx.data as *mut Environment) };
+    let memory = ctx.memory(0).view();
+
+    // TODO: Don't panic
+    let buf = &memory[buf..buf + buf_len];
+    if let Some(process) = &env.process {
+        let mut byte_buf = vec![0; buf.len()];
+        process.read_buf(address, &mut byte_buf).unwrap();
+        for (dst, src) in buf.iter().zip(byte_buf) {
+            dst.set(src);
+        }
     }
 }
+
+fn get_val<T>(
+    pointer_path_id: u32,
+    current: i32,
+    ctx: &mut Ctx,
+    convert: impl FnOnce(&PointerValue) -> Option<T>,
+) -> Result<T, EnvironmentError> {
+    let pointer_path_id = pointer_path_id as usize;
+    let current = current != 0;
+    let env = unsafe { &mut *(ctx.data as *mut Environment) };
+
+    let pointer_path = env
+        .pointer_paths
+        .get(pointer_path_id)
+        .ok_or_else(|| EnvironmentError::InvalidPointerPathId)
+        .unwrap();
+    let value = if current {
+        &pointer_path.current
+    } else {
+        &pointer_path.old
+    };
+
+    convert(value).ok_or(EnvironmentError::TypeMismatch)
+}
+
+// fn into_memory(extern_val: ExternVal) -> Result<MemoryRef, Box<Error>> {
+//     match extern_val {
+//         ExternVal::Memory(memory) => Ok(memory),
+//         _ => Err("Memory is not exported correctly".into()),
+//     }
+// }

--- a/crates/livesplit-auto-splitting/src/runtime.rs
+++ b/crates/livesplit-auto-splitting/src/runtime.rs
@@ -247,7 +247,7 @@ impl Runtime {
             }
             TimerState::Running => {
                 if let Ok(func) = self.instance.func::<(), i32>("is_loading") {
-                    let ret_val = func.call().map_err(|e| format!("Failed to run is_loading function: {}", e));
+                    let ret_val = func.call().map_err(|e| format!("Failed to run is_loading function: {}", e))?;
 
                     self.is_loading_val = Some(ret_val != 0);
                 }

--- a/crates/livesplit-auto-splitting/src/runtime.rs
+++ b/crates/livesplit-auto-splitting/src/runtime.rs
@@ -13,13 +13,6 @@ pub struct Runtime {
     instance: Instance,
     environment: Environment,
     timer_state: TimerState,
-    // should_start: Option<FuncRef>,
-    // should_split: Option<FuncRef>,
-    // should_reset: Option<FuncRef>,
-    // is_loading: Option<FuncRef>,
-    // game_time: Option<FuncRef>,
-    // update: Option<FuncRef>,
-    // disconnected: Option<FuncRef>,
     is_loading_val: Option<bool>,
     game_time_val: Option<f64>,
 }
@@ -134,39 +127,10 @@ impl Runtime {
             .call("configure", &[])
             .map_err(|e| format!("Failed to run configure function: {}", e))?;
 
-        // let should_start = instance
-        //     .export_by_name("should_start")
-        //     .and_then(|e| e.as_func()?.clone().into());
-        // let should_split = instance
-        //     .export_by_name("should_split")
-        //     .and_then(|e| e.as_func()?.clone().into());
-        // let should_reset = instance
-        //     .export_by_name("should_reset")
-        //     .and_then(|e| e.as_func()?.clone().into());
-        // let is_loading = instance
-        //     .export_by_name("is_loading")
-        //     .and_then(|e| e.as_func()?.clone().into());
-        // let game_time = instance
-        //     .export_by_name("game_time")
-        //     .and_then(|e| e.as_func()?.clone().into());
-        // let update = instance
-        //     .export_by_name("update")
-        //     .and_then(|e| e.as_func()?.clone().into());
-        // let disconnected = instance
-        //     .export_by_name("disconnected")
-        //     .and_then(|e| e.as_func()?.clone().into());
-
         Ok(Self {
             instance,
             environment,
             timer_state: TimerState::NotRunning,
-            // should_start,
-            // should_split,
-            // should_reset,
-            // is_loading,
-            // game_time,
-            // update,
-            // disconnected,
             is_loading_val: None,
             game_time_val: None,
         })
@@ -191,9 +155,9 @@ impl Runtime {
             // TODO: Only checks for disconnected if we actually have pointer paths
             log::info!(target: "Auto Splitter", "Unhooked");
             self.environment.process = None;
-            // if let Some(func) = &self.disconnected {
-            //     FuncInstance::invoke(func, &[], &mut self.environment)?;
-            // }
+            if let Ok(func) = self.instance.func::<(), ()>("disconnected") {
+                func.call().map_err(|e| format!("Failed to run disconnected function: {}", e));
+            }
             return Ok(None);
         }
         // println!("{:#?}", self.environment);
@@ -205,58 +169,60 @@ impl Runtime {
     }
 
     fn update_values(&mut self, just_connected: bool) -> Result<(), Box<Error>> {
-        // let process = self
-        //     .environment
-        //     .process
-        //     .as_mut()
-        //     .expect("The process should be connected at this point");
+        let process = self
+            .environment
+            .process
+            .as_mut()
+            .expect("The process should be connected at this point");
 
-        // for pointer_path in &mut self.environment.pointer_paths {
-        //     let mut address = if !pointer_path.module_name.is_empty() {
-        //         process.module_address(&pointer_path.module_name)?
-        //     } else {
-        //         0
-        //     };
-        //     let mut offsets = pointer_path.offsets.iter().cloned().peekable();
-        //     if process.is_64bit() {
-        //         while let Some(offset) = offsets.next() {
-        //             address = (address as Offset).wrapping_add(offset) as u64;
-        //             if offsets.peek().is_some() {
-        //                 address = process.read(address)?;
-        //             }
-        //         }
-        //     } else {
-        //         while let Some(offset) = offsets.next() {
-        //             address = (address as i32).wrapping_add(offset as i32) as u64;
-        //             if offsets.peek().is_some() {
-        //                 address = process.read::<u32>(address)? as u64;
-        //             }
-        //         }
-        //     }
-        //     match &mut pointer_path.old {
-        //         PointerValue::U8(v) => *v = process.read(address)?,
-        //         PointerValue::U16(v) => *v = process.read(address)?,
-        //         PointerValue::U32(v) => *v = process.read(address)?,
-        //         PointerValue::U64(v) => *v = process.read(address)?,
-        //         PointerValue::I8(v) => *v = process.read(address)?,
-        //         PointerValue::I16(v) => *v = process.read(address)?,
-        //         PointerValue::I32(v) => *v = process.read(address)?,
-        //         PointerValue::I64(v) => *v = process.read(address)?,
-        //         PointerValue::F32(v) => *v = process.read(address)?,
-        //         PointerValue::F64(v) => *v = process.read(address)?,
-        //         PointerValue::String(_) => unimplemented!(),
-        //     }
-        // }
+        let modules = process.modules()?;
 
-        // if just_connected {
-        //     for pointer_path in &mut self.environment.pointer_paths {
-        //         pointer_path.current.clone_from(&pointer_path.old);
-        //     }
-        // } else {
-        //     for pointer_path in &mut self.environment.pointer_paths {
-        //         mem::swap(&mut pointer_path.current, &mut pointer_path.old);
-        //     }
-        // }
+        for pointer_path in &mut self.environment.pointer_paths {
+            let mut address: usize = if !pointer_path.module_name.is_empty() {
+                *modules.get(&pointer_path.module_name).ok_or(crate::process::Error::ModuleDoesntExist)?
+            } else {
+                0
+            };
+            let mut offsets = pointer_path.offsets.iter().cloned().peekable();
+            // if process.is_64bit() {
+                while let Some(offset) = offsets.next() {
+                    address = (address as Offset).wrapping_add(offset as isize) as usize;
+                    if offsets.peek().is_some() {
+                        address = process.read(address)?;
+                    }
+                }
+            // } else {
+            //     while let Some(offset) = offsets.next() {
+            //         address = (address as i32).wrapping_add(offset as i32) as u64;
+            //         if offsets.peek().is_some() {
+            //             address = process.read::<u32>(address)? as u64;
+            //         }
+            //     }
+            // }
+            match &mut pointer_path.old {
+                PointerValue::U8(v) => *v = process.read(address)?,
+                PointerValue::U16(v) => *v = process.read(address)?,
+                PointerValue::U32(v) => *v = process.read(address)?,
+                PointerValue::U64(v) => *v = process.read(address)?,
+                PointerValue::I8(v) => *v = process.read(address)?,
+                PointerValue::I16(v) => *v = process.read(address)?,
+                PointerValue::I32(v) => *v = process.read(address)?,
+                PointerValue::I64(v) => *v = process.read(address)?,
+                PointerValue::F32(v) => *v = process.read(address)?,
+                PointerValue::F64(v) => *v = process.read(address)?,
+                PointerValue::String(_) => unimplemented!(),
+            }
+        }
+
+        if just_connected {
+            for pointer_path in &mut self.environment.pointer_paths {
+                pointer_path.current.clone_from(&pointer_path.old);
+            }
+        } else {
+            for pointer_path in &mut self.environment.pointer_paths {
+                mem::swap(&mut pointer_path.current, &mut pointer_path.old);
+            }
+        }
 
         Ok(())
     }
@@ -266,13 +232,13 @@ impl Runtime {
 
         if let Ok(func) = self.instance.func::<(), ()>("update") {
             // TODO: Don't panic
-            func.call().unwrap();
+            func.call().map_err(|e| format!("Failed to run update function: {}", e))?;
         }
 
         match &self.timer_state {
             TimerState::NotRunning => {
                 if let Ok(func) = self.instance.func::<(), i32>("should_start") {
-                    let ret_val = func.call().unwrap();
+                    let ret_val = func.call().map_err(|e| format!("Failed to run should_start function: {}", e))?;
 
                     if ret_val != 0 {
                         return Ok(Some(TimerAction::Start));
@@ -281,12 +247,12 @@ impl Runtime {
             }
             TimerState::Running => {
                 if let Ok(func) = self.instance.func::<(), i32>("is_loading") {
-                    let ret_val = func.call().unwrap();
+                    let ret_val = func.call().map_err(|e| format!("Failed to run is_loading function: {}", e));
 
                     self.is_loading_val = Some(ret_val != 0);
                 }
                 if let Ok(func) = self.instance.func::<(), f64>("game_time") {
-                    let ret_val = func.call().unwrap();
+                    let ret_val = func.call().map_err(|e| format!("Failed to run game_time function: {}", e))?;
 
                     self.game_time_val = if ret_val.is_nan() {
                         None
@@ -296,14 +262,14 @@ impl Runtime {
                 }
 
                 if let Ok(func) = self.instance.func::<(), i32>("should_split") {
-                    let ret_val = func.call().unwrap();
+                    let ret_val = func.call().map_err(|e| format!("Failed to run should_split function: {}", e))?;
 
                     if ret_val != 0 {
                         return Ok(Some(TimerAction::Split));
                     }
                 }
                 if let Ok(func) = self.instance.func::<(), i32>("should_reset") {
-                    let ret_val = func.call().unwrap();
+                    let ret_val = func.call().map_err(|e| format!("Failed to run should_reset function: {}", e))?;
 
                     if ret_val != 0 {
                         return Ok(Some(TimerAction::Reset));
@@ -312,7 +278,7 @@ impl Runtime {
             }
             TimerState::Finished => {
                 if let Ok(func) = self.instance.func::<(), i32>("should_reset") {
-                    let ret_val = func.call().unwrap();
+                    let ret_val = func.call().map_err(|e| format!("Failed to run should_reset function: {}", e))?;
 
                     if ret_val != 0 {
                         return Ok(Some(TimerAction::Reset));

--- a/crates/livesplit-auto-splitting/src/runtime.rs
+++ b/crates/livesplit-auto-splitting/src/runtime.rs
@@ -516,7 +516,7 @@ fn scan_signature(ctx: &mut Ctx, ptr: u32, len: u32) -> u64 {
     if let Some(process) = &env.process {
         let signature = read_string(&memory, ptr, len);
         let address = process.scan_signature(&signature).unwrap();
-        return address.unwrap_or(0);
+        return address.unwrap_or(0) as u64;
     }
 
     0

--- a/crates/livesplit-auto-splitting/src/runtime.rs
+++ b/crates/livesplit-auto-splitting/src/runtime.rs
@@ -1,7 +1,7 @@
 // use crate::environment::{Environment, Imports};
 use crate::pointer::PointerValue;
 use crate::process::{Offset, Process};
-use std::{collections::HashMap, error::Error, mem, str, thread, time::Duration};
+use std::{collections::HashMap, convert::TryInto, error::Error, mem, str, thread, time::Duration};
 // use wasmi::{
 //     ExternVal, FuncInstance, FuncRef, MemoryRef, Module, ModuleInstance, ModuleRef, RuntimeValue,
 // };
@@ -503,7 +503,7 @@ fn read_into_buf(ctx: &mut Ctx, address: u64, buf: u32, buf_len: u32) {
     let buf = &memory[buf..buf + buf_len];
     if let Some(process) = &env.process {
         let mut byte_buf = vec![0; buf.len()];
-        if process.read_buf(address, &mut byte_buf).is_err() {
+        if process.read_buf(address.try_into().unwrap(), &mut byte_buf).is_err() {
             // TODO: Handle error
         }
         for (dst, src) in buf.iter().zip(byte_buf) {

--- a/crates/livesplit-auto-splitting/src/runtime/wasi.rs
+++ b/crates/livesplit-auto-splitting/src/runtime/wasi.rs
@@ -1,0 +1,502 @@
+use super::Environment;
+use std::{cell::Cell, io, time::Instant};
+use wasmer_runtime::Ctx;
+use wasmer_runtime_core::memory::Memory;
+
+macro_rules! wasi_try {
+    ($expr:expr) => {{
+        let res: Result<_, crate::runtime::wasi::types::__wasi_errno_t> = $expr;
+        match res {
+            Ok(val) => {
+                log::info!("wasi::wasi_try::val: {:?}", val);
+                val
+            }
+            Err(err) => {
+                log::info!("wasi::wasi_try::err: {:?}", err);
+                return err;
+            }
+        }
+    }};
+    ($expr:expr; $e:expr) => {{
+        let opt: Option<_> = $expr;
+        wasi_try!(opt.ok_or($e))
+    }};
+}
+
+mod fs;
+mod ptr;
+mod types;
+
+pub use fs::FileSystem;
+use ptr::{Array, WasmPtr};
+use types::*;
+
+/// ### `fd_prestat_get()`
+/// Get metadata about a preopened file descriptor
+/// Input:
+/// - `__wasi_fd_t fd`
+///     The preopened file descriptor to query
+/// Output:
+/// - `__wasi_prestat *buf`
+///     Where the metadata will be written
+pub fn fd_prestat_get(
+    ctx: &mut Ctx,
+    fd: __wasi_fd_t,
+    buf: WasmPtr<__wasi_prestat_t>,
+) -> __wasi_errno_t {
+    log::info!("wasi::fd_prestat_get: fd={}", fd);
+    let memory = ctx.memory(0);
+
+    let prestat_ptr = wasi_try!(buf.deref(memory));
+
+    if fd != 3 {
+        return __WASI_EBADF;
+    }
+
+    // let state = get_wasi_state(ctx);
+    prestat_ptr.set(__wasi_prestat_t {
+        pr_type: __WASI_PREOPENTYPE_DIR,
+        u: PrestatEnum::Dir {
+            pr_name_len: "/".len() as u32,
+        }
+        .untagged(),
+    });
+
+    __WASI_ESUCCESS
+    // __WASI_EBADF
+}
+
+pub fn fd_prestat_dir_name(
+    ctx: &mut Ctx,
+    fd: __wasi_fd_t,
+    path: WasmPtr<u8, Array>,
+    path_len: u32,
+) -> __wasi_errno_t {
+    log::info!(
+        "wasi::fd_prestat_dir_name: fd={}, path_len={}",
+        fd,
+        path_len
+    );
+    let memory = ctx.memory(0);
+    let path_chars = wasi_try!(path.deref(memory, 0, path_len));
+
+    if fd != 3 {
+        return __WASI_EBADF;
+    }
+
+    let path = "/";
+    for (c, p) in path.bytes().zip(path_chars) {
+        p.set(c);
+    }
+
+    __WASI_ESUCCESS
+}
+
+/// ### `fd_filestat_get()`
+/// Get the metadata of an open file
+/// Input:
+/// - `__wasi_fd_t fd`
+///     The open file descriptor whose metadata will be read
+/// Output:
+/// - `__wasi_filestat_t *buf`
+///     Where the metadata from `fd` will be written
+pub fn fd_filestat_get(
+    ctx: &mut Ctx,
+    fd: __wasi_fd_t,
+    buf: WasmPtr<__wasi_filestat_t>,
+) -> __wasi_errno_t {
+    log::info!("wasi::fd_filestat_get");
+    let env = unsafe { &mut *(ctx.data as *mut Environment) };
+    let memory = ctx.memory(0);
+    env.fs.fd_filestat_get(memory, fd, buf)
+}
+
+/// ### `environ_sizes_get()`
+/// Return command-line argument data sizes.
+/// Outputs:
+/// - `size_t *environ_count`
+///     The number of environment variables.
+/// - `size_t *environ_buf_size`
+///     The size of the environment variable string data.
+pub fn environ_sizes_get(
+    ctx: &mut Ctx,
+    environ_count: WasmPtr<u32>,
+    environ_buf_size: WasmPtr<u32>,
+) -> __wasi_errno_t {
+    log::info!("wasi::environ_sizes_get");
+    let memory = ctx.memory(0);
+
+    let environ_count = wasi_try!(environ_count.deref(memory));
+    let environ_buf_size = wasi_try!(environ_buf_size.deref(memory));
+
+    environ_count.set(0);
+    environ_buf_size.set(0);
+
+    __WASI_ESUCCESS
+}
+
+/// ### `environ_get()`
+/// Read environment variable data.
+/// The sizes of the buffers should match that returned by [`environ_sizes_get()`](#environ_sizes_get).
+/// Inputs:
+/// - `char **environ`
+///     A pointer to a buffer to write the environment variable pointers.
+/// - `char *environ_buf`
+///     A pointer to a buffer to write the environment variable string data.
+pub fn environ_get(
+    ctx: &mut Ctx,
+    environ: WasmPtr<WasmPtr<u8, Array>, Array>,
+    environ_buf: WasmPtr<u8, Array>,
+) -> __wasi_errno_t {
+    unimplemented!()
+}
+
+/// ### `args_sizes_get()`
+/// Return command-line argument data sizes.
+/// Outputs:
+/// - `size_t *argc`
+///     The number of arguments.
+/// - `size_t *argv_buf_size`
+///     The size of the argument string data.
+pub fn args_sizes_get(
+    ctx: &mut Ctx,
+    argc: WasmPtr<u32>,
+    argv_buf_size: WasmPtr<u32>,
+) -> __wasi_errno_t {
+    log::info!("wasi::args_sizes_get");
+    let memory = ctx.memory(0);
+
+    let argc = wasi_try!(argc.deref(memory));
+    let argv_buf_size = wasi_try!(argv_buf_size.deref(memory));
+
+    let argc_val = 0u32;
+    let argv_buf_size_val = 0u32;
+    argc.set(argc_val);
+    argv_buf_size.set(argv_buf_size_val);
+
+    log::info!("=> argc={}, argv_buf_size={}", argc_val, argv_buf_size_val);
+
+    __WASI_ESUCCESS
+}
+
+/// ### `args_get()`
+/// Read command-line argument data.
+/// The sizes of the buffers should match that returned by [`args_sizes_get()`](#args_sizes_get).
+/// Inputs:
+/// - `char **argv`
+///     A pointer to a buffer to write the argument pointers.
+/// - `char *argv_buf`
+///     A pointer to a buffer to write the argument string data.
+///
+pub fn args_get(
+    ctx: &mut Ctx,
+    argv: WasmPtr<WasmPtr<u8, Array>, Array>,
+    argv_buf: WasmPtr<u8, Array>,
+) -> __wasi_errno_t {
+    log::info!("wasi::args_get");
+    let memory = ctx.memory(0);
+    let result = write_buffer_array(memory, &[], argv, argv_buf);
+    result
+}
+
+/// ### `fd_write()`
+/// Write data to the file descriptor
+/// Inputs:
+/// - `__wasi_fd_t`
+///     File descriptor (opened with writing) to write to
+/// - `const __wasi_ciovec_t *iovs`
+///     List of vectors to read data from
+/// - `u32 iovs_len`
+///     Length of data in `iovs`
+/// Output:
+/// - `u32 *nwritten`
+///     Number of bytes written
+/// Errors:
+///
+pub fn fd_write(
+    ctx: &mut Ctx,
+    fd: __wasi_fd_t,
+    iovs: WasmPtr<__wasi_ciovec_t, Array>,
+    iovs_len: u32,
+    nwritten: WasmPtr<u32>,
+) -> __wasi_errno_t {
+    log::info!("wasi::fd_write: fd={}", fd);
+    let env = unsafe { &mut *(ctx.data as *mut Environment) };
+    let memory = ctx.memory(0);
+    env.fs.fd_write(memory, fd, iovs, iovs_len, nwritten)
+}
+
+/// ### `fd_seek()`
+/// Update file descriptor offset
+/// Inputs:
+/// - `__wasi_fd_t fd`
+///     File descriptor to mutate
+/// - `__wasi_filedelta_t offset`
+///     Number of bytes to adjust offset by
+/// - `__wasi_whence_t whence`
+///     What the offset is relative to
+/// Output:
+/// - `__wasi_filesize_t *fd`
+///     The new offset relative to the start of the file
+pub fn fd_seek(
+    ctx: &mut Ctx,
+    fd: __wasi_fd_t,
+    offset: __wasi_filedelta_t,
+    whence: __wasi_whence_t,
+    newoffset: WasmPtr<__wasi_filesize_t>,
+) -> __wasi_errno_t {
+    log::info!("wasi::fd_seek: fd={}, offset={}", fd, offset);
+    let env = unsafe { &mut *(ctx.data as *mut Environment) };
+    let memory = ctx.memory(0);
+    env.fs.fd_seek(memory, fd, offset, whence, newoffset)
+}
+
+pub fn proc_exit(ctx: &mut Ctx, code: __wasi_exitcode_t) {
+    unimplemented!()
+}
+
+/// ### `fd_fdstat_get()`
+/// Get metadata of a file descriptor
+/// Input:
+/// - `__wasi_fd_t fd`
+///     The file descriptor whose metadata will be accessed
+/// Output:
+/// - `__wasi_fdstat_t *buf`
+///     The location where the metadata will be written
+pub fn fd_fdstat_get(
+    ctx: &mut Ctx,
+    fd: __wasi_fd_t,
+    buf_ptr: WasmPtr<__wasi_fdstat_t>,
+) -> __wasi_errno_t {
+    log::info!(
+        "wasi::fd_fdstat_get: fd={}, buf_ptr={}",
+        fd,
+        buf_ptr.offset()
+    );
+    let env = unsafe { &mut *(ctx.data as *mut Environment) };
+    let memory = ctx.memory(0);
+    env.fs.fd_fdstat_get(memory, fd, buf_ptr)
+}
+
+fn write_bytes<T: io::Write>(
+    mut write_loc: T,
+    memory: &Memory,
+    iovs_arr_cell: &[Cell<__wasi_ciovec_t>],
+) -> Result<u32, __wasi_errno_t> {
+    let mut bytes_written = 0;
+    for iov in iovs_arr_cell {
+        let iov_inner = iov.get();
+        let bytes = iov_inner.buf.deref(memory, 0, iov_inner.buf_len)?;
+        write_loc
+            .write(&bytes.iter().map(|b_cell| b_cell.get()).collect::<Vec<u8>>())
+            .map_err(|_| {
+                write_loc.flush();
+                __WASI_EIO
+            })?;
+
+        // TODO: handle failure more accurately
+        bytes_written += iov_inner.buf_len;
+    }
+    write_loc.flush();
+    Ok(bytes_written)
+}
+
+/// ### `fd_close()`
+/// Close an open file descriptor
+/// Inputs:
+/// - `__wasi_fd_t fd`
+///     A file descriptor mapping to an open file to close
+/// Errors:
+/// - `__WASI_EISDIR`
+///     If `fd` is a directory
+/// - `__WASI_EBADF`
+///     If `fd` is invalid or not open (TODO: consider __WASI_EINVAL)
+pub fn fd_close(ctx: &mut Ctx, fd: __wasi_fd_t) -> __wasi_errno_t {
+    log::info!("wasi::fd_close: fd={}", fd);
+    let env = unsafe { &mut *(ctx.data as *mut Environment) };
+    let memory = ctx.memory(0);
+    env.fs.fd_close(memory, fd)
+}
+
+/// ### `path_open()`
+/// Open file located at the given path
+/// Inputs:
+/// - `__wasi_fd_t dirfd`
+///     The fd corresponding to the directory that the file is in
+/// - `__wasi_lookupflags_t dirflags`
+///     Flags specifying how the path will be resolved
+/// - `char *path`
+///     The path of the file or directory to open
+/// - `u32 path_len`
+///     The length of the `path` string
+/// - `__wasi_oflags_t o_flags`
+///     How the file will be opened
+/// - `__wasi_rights_t fs_rights_base`
+///     The rights of the created file descriptor
+/// - `__wasi_rights_t fs_rightsinheriting`
+///     The rights of file descriptors derived from the created file descriptor
+/// - `__wasi_fdflags_t fs_flags`
+///     The flags of the file descriptor
+/// Output:
+/// - `__wasi_fd_t* fd`
+///     The new file descriptor
+/// Possible Errors:
+/// - `__WASI_EACCES`, `__WASI_EBADF`, `__WASI_EFAULT`, `__WASI_EFBIG?`, `__WASI_EINVAL`, `__WASI_EIO`, `__WASI_ELOOP`, `__WASI_EMFILE`, `__WASI_ENAMETOOLONG?`, `__WASI_ENFILE`, `__WASI_ENOENT`, `__WASI_ENOTDIR`, `__WASI_EROFS`, and `__WASI_ENOTCAPABLE`
+pub fn path_open(
+    ctx: &mut Ctx,
+    dirfd: __wasi_fd_t,
+    dirflags: __wasi_lookupflags_t,
+    path: WasmPtr<u8, Array>,
+    path_len: u32,
+    o_flags: __wasi_oflags_t,
+    fs_rights_base: __wasi_rights_t,
+    fs_rights_inheriting: __wasi_rights_t,
+    fs_flags: __wasi_fdflags_t,
+    fd: WasmPtr<__wasi_fd_t>,
+) -> __wasi_errno_t {
+    log::info!("wasi::path_open");
+    let env = unsafe { &mut *(ctx.data as *mut Environment) };
+    let memory = ctx.memory(0);
+    env.fs.path_open(
+        memory,
+        dirfd,
+        dirflags,
+        path,
+        path_len,
+        o_flags,
+        fs_rights_base,
+        fs_rights_inheriting,
+        fs_flags,
+        fd,
+    )
+}
+
+/// ### `fd_read()`
+/// Read data from file descriptor
+/// Inputs:
+/// - `__wasi_fd_t fd`
+///     File descriptor from which data will be read
+/// - `const __wasi_iovec_t *iovs`
+///     Vectors where data will be stored
+/// - `u32 iovs_len`
+///     Length of data in `iovs`
+/// Output:
+/// - `u32 *nread`
+///     Number of bytes read
+pub fn fd_read(
+    ctx: &mut Ctx,
+    fd: __wasi_fd_t,
+    iovs: WasmPtr<__wasi_iovec_t, Array>,
+    iovs_len: u32,
+    nread: WasmPtr<u32>,
+) -> __wasi_errno_t {
+    log::info!("wasi::fd_read: fd={}", fd);
+    let env = unsafe { &mut *(ctx.data as *mut Environment) };
+    let memory = ctx.memory(0);
+    env.fs.fd_read(memory, fd, iovs, iovs_len, nread)
+}
+
+/// ### `clock_time_get()`
+/// Get the time of the specified clock
+/// Inputs:
+/// - `__wasi_clockid_t clock_id`
+///     The ID of the clock to query
+/// - `__wasi_timestamp_t precision`
+///     The maximum amount of error the reading may have
+/// Output:
+/// - `__wasi_timestamp_t *time`
+///     The value of the clock in nanoseconds
+pub fn clock_time_get(
+    ctx: &mut Ctx,
+    clock_id: __wasi_clockid_t,
+    precision: __wasi_timestamp_t,
+    time: WasmPtr<__wasi_timestamp_t>,
+) -> __wasi_errno_t {
+    log::info!("wasi::clock_time_get");
+    let memory = ctx.memory(0);
+
+    let out_addr = wasi_try!(time.deref(memory));
+    if clock_id != __WASI_CLOCK_MONOTONIC {
+        return __WASI_ENOTCAPABLE;
+    }
+    lazy_static::lazy_static! {
+        static ref INITIAL: Instant = Instant::now();
+    }
+    // TODO: Precision
+    out_addr.set(INITIAL.elapsed().as_nanos() as _);
+
+    __WASI_ESUCCESS
+}
+
+/// ### `random_get()`
+/// Fill buffer with high-quality random data.  This function may be slow and block
+/// Inputs:
+/// - `void *buf`
+///     A pointer to a buffer where the random bytes will be written
+/// - `size_t buf_len`
+///     The number of bytes that will be written
+pub fn random_get(ctx: &mut Ctx, buf: WasmPtr<u8, Array>, buf_len: u32) -> __wasi_errno_t {
+    log::info!("wasi::random_get");
+    use rand::Rng;
+    let mut rng = rand::thread_rng();
+    let memory = ctx.memory(0);
+
+    let buf = wasi_try!(buf.deref(memory, 0, buf_len));
+
+    unsafe {
+        let u8_buffer = &mut *(buf as *const [_] as *mut [_] as *mut [u8]);
+        rng.fill(u8_buffer);
+    }
+
+    __WASI_ESUCCESS
+}
+
+fn read_bytes<T: io::Read>(
+    mut reader: T,
+    memory: &Memory,
+    iovs_arr_cell: &[Cell<__wasi_iovec_t>],
+) -> Result<u32, __wasi_errno_t> {
+    let mut bytes_read = 0;
+
+    for iov in iovs_arr_cell {
+        let iov_inner = iov.get();
+        let bytes = iov_inner.buf.deref(memory, 0, iov_inner.buf_len)?;
+        let raw_bytes: &mut [u8] = unsafe { &mut *(bytes as *const [_] as *mut [_] as *mut [u8]) };
+        bytes_read += reader.read(raw_bytes).map_err(|_| __WASI_EIO)? as u32;
+    }
+    Ok(bytes_read)
+}
+
+fn write_bytes_to_string(
+    memory: &Memory,
+    iovs_arr_cell: &[Cell<__wasi_ciovec_t>],
+) -> Result<(u32, String), __wasi_errno_t> {
+    let mut bytes = Vec::new();
+    let bytes_written = write_bytes(&mut bytes, memory, iovs_arr_cell)?;
+    Ok((bytes_written, String::from_utf8_lossy(&bytes).into_owned()))
+}
+
+#[must_use]
+fn write_buffer_array(
+    memory: &Memory,
+    from: &[Vec<u8>],
+    ptr_buffer: WasmPtr<WasmPtr<u8, Array>, Array>,
+    buffer: WasmPtr<u8, Array>,
+) -> __wasi_errno_t {
+    let ptrs = wasi_try!(ptr_buffer.deref(memory, 0, from.len() as u32));
+
+    let mut current_buffer_offset = 0;
+    for ((i, sub_buffer), ptr) in from.iter().enumerate().zip(ptrs.iter()) {
+        ptr.set(WasmPtr::new(buffer.offset() + current_buffer_offset));
+
+        let cells =
+            wasi_try!(buffer.deref(memory, current_buffer_offset, sub_buffer.len() as u32 + 1));
+
+        for (cell, &byte) in cells.iter().zip(sub_buffer.iter().chain([0].iter())) {
+            cell.set(byte);
+        }
+        current_buffer_offset += sub_buffer.len() as u32 + 1;
+    }
+
+    __WASI_ESUCCESS
+}

--- a/crates/livesplit-auto-splitting/src/runtime/wasi/fs.rs
+++ b/crates/livesplit-auto-splitting/src/runtime/wasi/fs.rs
@@ -1,0 +1,209 @@
+use super::{
+    ptr::{Array, WasmPtr},
+    read_bytes,
+    types::*,
+    write_bytes_to_string,
+};
+use std::{
+    fs::File,
+    io::{Seek, SeekFrom},
+    time::SystemTime,
+};
+use wasmer_runtime::Memory;
+
+pub struct FileSystem {
+    files: Vec<Option<File>>,
+}
+
+impl FileSystem {
+    pub fn new() -> Self {
+        Self { files: vec![] }
+    }
+
+    pub fn fd_fdstat_get(
+        &mut self,
+        memory: &Memory,
+        fd: __wasi_fd_t,
+        buf_ptr: WasmPtr<__wasi_fdstat_t>,
+    ) -> __wasi_errno_t {
+        if fd != 3 {
+            return __WASI_EBADF;
+        }
+
+        let stat = __wasi_fdstat_t {
+            fs_filetype: __WASI_FILETYPE_DIRECTORY,
+            fs_flags: 0,
+            fs_rights_base: 0x1FFFFFFF, // all rights for now
+            fs_rights_inheriting: 0x1FFFFFFF,
+        };
+        let buf = wasi_try!(buf_ptr.deref(memory));
+
+        buf.set(stat);
+
+        __WASI_ESUCCESS
+    }
+
+    pub fn fd_write(
+        &mut self,
+        memory: &Memory,
+        fd: __wasi_fd_t,
+        iovs: WasmPtr<__wasi_ciovec_t, Array>,
+        iovs_len: u32,
+        nwritten: WasmPtr<u32>,
+    ) -> __wasi_errno_t {
+        let iovs_arr_cell = wasi_try!(iovs.deref(memory, 0, iovs_len));
+        let nwritten_cell = wasi_try!(nwritten.deref(memory));
+        if fd < 1 || fd > 2 {
+            return __WASI_EBADF;
+        }
+
+        let (bytes_written, text) = wasi_try!(write_bytes_to_string(memory, iovs_arr_cell));
+        if fd == 1 {
+            log::info!(target: "Auto Splitter", "{}", text);
+        } else {
+            log::error!(target: "Auto Splitter", "{}", text);
+        }
+        nwritten_cell.set(bytes_written);
+
+        __WASI_ESUCCESS
+    }
+
+    pub fn path_open(
+        &mut self,
+        memory: &Memory,
+        dirfd: __wasi_fd_t,
+        dirflags: __wasi_lookupflags_t,
+        path: WasmPtr<u8, Array>,
+        path_len: u32,
+        o_flags: __wasi_oflags_t,
+        fs_rights_base: __wasi_rights_t,
+        fs_rights_inheriting: __wasi_rights_t,
+        fs_flags: __wasi_fdflags_t,
+        fd: WasmPtr<__wasi_fd_t>,
+    ) -> __wasi_errno_t {
+        let file = File::open(r"livesplit-core\README.md").unwrap();
+        let fd_val = if let Some((i, slot)) = self
+            .files
+            .iter_mut()
+            .enumerate()
+            .find(|(_, slot)| slot.is_none())
+        {
+            *slot = Some(file);
+            i + 4
+        } else {
+            let i = self.files.len();
+            self.files.push(Some(file));
+            i + 4
+        };
+
+        wasi_try!(fd.deref(memory)).set(fd_val as __wasi_fd_t);
+
+        __WASI_ESUCCESS
+    }
+
+    pub fn fd_close(&mut self, memory: &Memory, fd: __wasi_fd_t) -> __wasi_errno_t {
+        if let Some(slot) = (fd as usize)
+            .checked_sub(4)
+            .and_then(|i| self.files.get_mut(i))
+        {
+            *slot = None;
+            __WASI_ESUCCESS
+        } else {
+            __WASI_EBADF
+        }
+    }
+
+    pub fn fd_read(
+        &mut self,
+        memory: &Memory,
+        fd: __wasi_fd_t,
+        iovs: WasmPtr<__wasi_iovec_t, Array>,
+        iovs_len: u32,
+        nread: WasmPtr<u32>,
+    ) -> __wasi_errno_t {
+        let iovs_arr_cell = wasi_try!(iovs.deref(memory, 0, iovs_len));
+        let nread_cell = wasi_try!(nread.deref(memory));
+
+        if let Some(Some(file)) = (fd as usize).checked_sub(4).and_then(|i| self.files.get(i)) {
+            let bytes_read = wasi_try!(read_bytes(file, memory, iovs_arr_cell));
+            nread_cell.set(bytes_read);
+            __WASI_ESUCCESS
+        } else {
+            __WASI_EBADF
+        }
+    }
+
+    pub fn fd_filestat_get(
+        &mut self,
+        memory: &Memory,
+        fd: __wasi_fd_t,
+        buf: WasmPtr<__wasi_filestat_t>,
+    ) -> __wasi_errno_t {
+        let buf_cell = wasi_try!(buf.deref(memory));
+
+        if let Some(Some(file)) = (fd as usize).checked_sub(4).and_then(|i| self.files.get(i)) {
+            let meta = wasi_try!(file.metadata().map_err(|_| __WASI_EIO));
+
+            buf_cell.set(__wasi_filestat_t {
+                st_filetype: if meta.file_type().is_file() {
+                    __WASI_FILETYPE_REGULAR_FILE
+                } else if meta.file_type().is_dir() {
+                    __WASI_FILETYPE_DIRECTORY
+                } else if meta.file_type().is_symlink() {
+                    __WASI_FILETYPE_SYMBOLIC_LINK
+                } else {
+                    __WASI_FILETYPE_UNKNOWN
+                },
+                st_size: meta.len(),
+                st_atim: meta
+                    .accessed()
+                    .ok()
+                    .and_then(|sys_time| sys_time.duration_since(SystemTime::UNIX_EPOCH).ok())
+                    .map(|duration| duration.as_nanos() as u64)
+                    .unwrap_or(0),
+                st_ctim: meta
+                    .created()
+                    .ok()
+                    .and_then(|sys_time| sys_time.duration_since(SystemTime::UNIX_EPOCH).ok())
+                    .map(|duration| duration.as_nanos() as u64)
+                    .unwrap_or(0),
+                st_mtim: meta
+                    .modified()
+                    .ok()
+                    .and_then(|sys_time| sys_time.duration_since(SystemTime::UNIX_EPOCH).ok())
+                    .map(|duration| duration.as_nanos() as u64)
+                    .unwrap_or(0),
+                ..__wasi_filestat_t::default()
+            });
+
+            __WASI_ESUCCESS
+        } else {
+            __WASI_EBADF
+        }
+    }
+
+    pub fn fd_seek(
+        &mut self,
+        memory: &Memory,
+        fd: __wasi_fd_t,
+        offset: __wasi_filedelta_t,
+        whence: __wasi_whence_t,
+        newoffset: WasmPtr<__wasi_filesize_t>,
+    ) -> __wasi_errno_t {
+        let newoffset_cell = wasi_try!(newoffset.deref(memory));
+        if let Some(Some(file)) = (fd as usize).checked_sub(4).and_then(|i| self.files.get(i)) {
+            let seek_from = match whence {
+                __WASI_WHENCE_CUR => SeekFrom::Current(offset),
+                __WASI_WHENCE_END => SeekFrom::End(offset),
+                __WASI_WHENCE_SET => SeekFrom::Start(offset as _),
+                _ => return __WASI_EINVAL,
+            };
+            let mut file = file;
+            let new_offset = wasi_try!(file.seek(seek_from).map_err(|_| __WASI_EIO));
+            newoffset_cell.set(new_offset);
+            __WASI_ESUCCESS
+        } else {
+            __WASI_EBADF
+        }
+    }
+}

--- a/crates/livesplit-auto-splitting/src/runtime/wasi/ptr.rs
+++ b/crates/livesplit-auto-splitting/src/runtime/wasi/ptr.rs
@@ -1,0 +1,122 @@
+use super::types::{__wasi_errno_t, __WASI_EFAULT};
+use std::{cell::Cell, fmt, marker::PhantomData, mem};
+use wasmer_runtime_core::{
+    memory::Memory,
+    types::{Type, ValueType, WasmExternType},
+};
+
+pub struct Array;
+pub struct Item;
+
+#[repr(transparent)]
+pub struct WasmPtr<T: Copy, Ty = Item> {
+    offset: u32,
+    _phantom: PhantomData<(T, Ty)>,
+}
+
+impl<T: Copy, Ty> WasmPtr<T, Ty> {
+    #[inline]
+    pub fn new(offset: u32) -> Self {
+        Self {
+            offset,
+            _phantom: PhantomData,
+        }
+    }
+
+    #[inline]
+    pub fn offset(self) -> u32 {
+        self.offset
+    }
+}
+
+impl<T: Copy + ValueType> WasmPtr<T, Item> {
+    #[inline]
+    pub fn deref<'a>(self, memory: &'a Memory) -> Result<&'a Cell<T>, __wasi_errno_t> {
+        if (self.offset as usize) + mem::size_of::<T>() >= memory.size().bytes().0 {
+            return Err(__WASI_EFAULT);
+        }
+        unsafe {
+            // clears bits below aligment amount (assumes power of 2) to align pointer
+            let aligner = |ptr: usize, align: usize| ptr & !(align - 1);
+            let cell_ptr = aligner(
+                memory.view::<u8>().as_ptr().add(self.offset as usize) as usize,
+                mem::align_of::<T>(),
+            ) as *const Cell<T>;
+            Ok(&*cell_ptr)
+        }
+    }
+}
+
+impl<T: Copy + ValueType> WasmPtr<T, Array> {
+    #[inline]
+    pub fn deref<'a>(
+        self,
+        memory: &'a Memory,
+        index: u32,
+        length: u32,
+    ) -> Result<&'a [Cell<T>], __wasi_errno_t> {
+        if (self.offset as usize) + (mem::size_of::<T>() * ((index + length) as usize))
+            >= memory.size().bytes().0
+        {
+            return Err(__WASI_EFAULT);
+        }
+
+        unsafe {
+            let cell_ptrs = memory.view::<T>().get_unchecked(
+                ((self.offset as usize) / mem::size_of::<T>()) + (index as usize)
+                    ..((self.offset() as usize) / mem::size_of::<T>())
+                        + ((index + length) as usize),
+            ) as *const _;
+            Ok(&*cell_ptrs)
+        }
+    }
+}
+
+unsafe impl<T: Copy, Ty> WasmExternType for WasmPtr<T, Ty> {
+    // fn to_native(self) -> Self::Native {
+    //     self.offset as i32
+    // }
+    // fn from_native(n: Self::Native) -> Self {
+    //     Self {
+    //         offset: n as u32,
+    //         _phantom: PhantomData,
+    //     }
+    // }
+    const TYPE: Type = Type::I32;
+    fn to_bits(self) -> u64 {
+        self.offset as i32 as u64
+    }
+    fn from_bits(n: u64) -> Self {
+        Self {
+            offset: n as i32 as u32,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+unsafe impl<T: Copy, Ty> ValueType for WasmPtr<T, Ty> {}
+
+impl<T: Copy, Ty> Clone for WasmPtr<T, Ty> {
+    fn clone(&self) -> Self {
+        Self {
+            offset: self.offset,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<T: Copy, Ty> Copy for WasmPtr<T, Ty> {}
+
+impl<T: Copy, Ty> PartialEq for WasmPtr<T, Ty> {
+    fn eq(&self, other: &Self) -> bool {
+        self.offset == other.offset
+    }
+}
+
+impl<T: Copy, Ty> Eq for WasmPtr<T, Ty> {}
+
+impl<T: Copy, Ty> fmt::Debug for WasmPtr<T, Ty> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "WasmPtr({:#x})", self.offset)
+    }
+}

--- a/crates/livesplit-auto-splitting/src/runtime/wasi/ptr.rs
+++ b/crates/livesplit-auto-splitting/src/runtime/wasi/ptr.rs
@@ -2,7 +2,7 @@ use super::types::{__wasi_errno_t, __WASI_EFAULT};
 use std::{cell::Cell, fmt, marker::PhantomData, mem};
 use wasmer_runtime_core::{
     memory::Memory,
-    types::{Type, ValueType, WasmExternType},
+    types::{ValueType, WasmExternType},
 };
 
 pub struct Array;
@@ -73,22 +73,14 @@ impl<T: Copy + ValueType> WasmPtr<T, Array> {
 }
 
 unsafe impl<T: Copy, Ty> WasmExternType for WasmPtr<T, Ty> {
-    // fn to_native(self) -> Self::Native {
-    //     self.offset as i32
-    // }
-    // fn from_native(n: Self::Native) -> Self {
-    //     Self {
-    //         offset: n as u32,
-    //         _phantom: PhantomData,
-    //     }
-    // }
-    const TYPE: Type = Type::I32;
-    fn to_bits(self) -> u64 {
-        self.offset as i32 as u64
+    type Native = i32;
+
+    fn to_native(self) -> Self::Native {
+        self.offset as i32
     }
-    fn from_bits(n: u64) -> Self {
+    fn from_native(n: Self::Native) -> Self {
         Self {
-            offset: n as i32 as u32,
+            offset: n as u32,
             _phantom: PhantomData,
         }
     }

--- a/crates/livesplit-auto-splitting/src/runtime/wasi/types.rs
+++ b/crates/livesplit-auto-splitting/src/runtime/wasi/types.rs
@@ -1,0 +1,460 @@
+#![allow(non_camel_case_types)]
+
+// use crate::ptr::{Array, WasmPtr};
+// use byteorder::{ReadBytesExt, WriteBytesExt, LE};
+use super::ptr::{Array, WasmPtr};
+use std::fmt;
+// use std::mem;
+use wasmer_runtime_core::types::ValueType;
+
+pub type __wasi_advice_t = u8;
+pub const __WASI_ADVICE_DONTNEED: u8 = 0;
+pub const __WASI_ADVICE_NOREUSE: u8 = 1;
+pub const __WASI_ADVICE_NORMAL: u8 = 2;
+pub const __WASI_ADVICE_RANDOM: u8 = 3;
+pub const __WASI_ADVICE_SEQUENTIAL: u8 = 4;
+pub const __WASI_ADVICE_WILLNEED: u8 = 5;
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[repr(C)]
+pub struct __wasi_ciovec_t {
+    pub buf: WasmPtr<u8, Array>,
+    pub buf_len: u32,
+}
+
+unsafe impl ValueType for __wasi_ciovec_t {}
+
+pub type __wasi_clockid_t = u32;
+pub const __WASI_CLOCK_REALTIME: u32 = 0;
+pub const __WASI_CLOCK_MONOTONIC: u32 = 1;
+pub const __WASI_CLOCK_PROCESS_CPUTIME_ID: u32 = 2;
+pub const __WASI_CLOCK_THREAD_CPUTIME_ID: u32 = 3;
+
+pub type __wasi_device_t = u64;
+
+pub type __wasi_dircookie_t = u64;
+pub const __WASI_DIRCOOKIE_START: u64 = 0;
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[repr(C)]
+pub struct __wasi_dirent_t {
+    pub d_next: __wasi_dircookie_t,
+    pub d_ino: __wasi_inode_t,
+    pub d_namlen: u32,
+    pub d_type: __wasi_filetype_t,
+}
+
+pub type __wasi_errno_t = u16;
+pub const __WASI_ESUCCESS: u16 = 0;
+pub const __WASI_E2BIG: u16 = 1;
+pub const __WASI_EACCES: u16 = 2;
+pub const __WASI_EADDRINUSE: u16 = 3;
+pub const __WASI_EADDRNOTAVAIL: u16 = 4;
+pub const __WASI_EAFNOSUPPORT: u16 = 5;
+pub const __WASI_EAGAIN: u16 = 6;
+pub const __WASI_EALREADY: u16 = 7;
+pub const __WASI_EBADF: u16 = 8;
+pub const __WASI_EBADMSG: u16 = 9;
+pub const __WASI_EBUSY: u16 = 10;
+pub const __WASI_ECANCELED: u16 = 11;
+pub const __WASI_ECHILD: u16 = 12;
+pub const __WASI_ECONNABORTED: u16 = 13;
+pub const __WASI_ECONNREFUSED: u16 = 14;
+pub const __WASI_ECONNRESET: u16 = 15;
+pub const __WASI_EDEADLK: u16 = 16;
+pub const __WASI_EDESTADDRREQ: u16 = 17;
+pub const __WASI_EDOM: u16 = 18;
+pub const __WASI_EDQUOT: u16 = 19;
+pub const __WASI_EEXIST: u16 = 20;
+pub const __WASI_EFAULT: u16 = 21;
+pub const __WASI_EFBIG: u16 = 22;
+pub const __WASI_EHOSTUNREACH: u16 = 23;
+pub const __WASI_EIDRM: u16 = 24;
+pub const __WASI_EILSEQ: u16 = 25;
+pub const __WASI_EINPROGRESS: u16 = 26;
+pub const __WASI_EINTR: u16 = 27;
+pub const __WASI_EINVAL: u16 = 28;
+pub const __WASI_EIO: u16 = 29;
+pub const __WASI_EISCONN: u16 = 30;
+pub const __WASI_EISDIR: u16 = 31;
+pub const __WASI_ELOOP: u16 = 32;
+pub const __WASI_EMFILE: u16 = 33;
+pub const __WASI_EMLINK: u16 = 34;
+pub const __WASI_EMSGSIZE: u16 = 35;
+pub const __WASI_EMULTIHOP: u16 = 36;
+pub const __WASI_ENAMETOOLONG: u16 = 37;
+pub const __WASI_ENETDOWN: u16 = 38;
+pub const __WASI_ENETRESET: u16 = 39;
+pub const __WASI_ENETUNREACH: u16 = 40;
+pub const __WASI_ENFILE: u16 = 41;
+pub const __WASI_ENOBUFS: u16 = 42;
+pub const __WASI_ENODEV: u16 = 43;
+pub const __WASI_ENOENT: u16 = 44;
+pub const __WASI_ENOEXEC: u16 = 45;
+pub const __WASI_ENOLCK: u16 = 46;
+pub const __WASI_ENOLINK: u16 = 47;
+pub const __WASI_ENOMEM: u16 = 48;
+pub const __WASI_ENOMSG: u16 = 49;
+pub const __WASI_ENOPROTOOPT: u16 = 50;
+pub const __WASI_ENOSPC: u16 = 51;
+pub const __WASI_ENOSYS: u16 = 52;
+pub const __WASI_ENOTCONN: u16 = 53;
+pub const __WASI_ENOTDIR: u16 = 54;
+pub const __WASI_ENOTEMPTY: u16 = 55;
+pub const __WASI_ENOTRECOVERABLE: u16 = 56;
+pub const __WASI_ENOTSOCK: u16 = 57;
+pub const __WASI_ENOTSUP: u16 = 58;
+pub const __WASI_ENOTTY: u16 = 59;
+pub const __WASI_ENXIO: u16 = 60;
+pub const __WASI_EOVERFLOW: u16 = 61;
+pub const __WASI_EOWNERDEAD: u16 = 62;
+pub const __WASI_EPERM: u16 = 63;
+pub const __WASI_EPIPE: u16 = 64;
+pub const __WASI_EPROTO: u16 = 65;
+pub const __WASI_EPROTONOSUPPORT: u16 = 66;
+pub const __WASI_EPROTOTYPE: u16 = 67;
+pub const __WASI_ERANGE: u16 = 68;
+pub const __WASI_EROFS: u16 = 69;
+pub const __WASI_ESPIPE: u16 = 70;
+pub const __WASI_ESRCH: u16 = 71;
+pub const __WASI_ESTALE: u16 = 72;
+pub const __WASI_ETIMEDOUT: u16 = 73;
+pub const __WASI_ETXTBSY: u16 = 74;
+pub const __WASI_EXDEV: u16 = 75;
+pub const __WASI_ENOTCAPABLE: u16 = 76;
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[repr(C)]
+pub struct __wasi_event_fd_readwrite_t {
+    pub nbytes: __wasi_filesize_t,
+    pub flags: __wasi_eventrwflags_t,
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub union __wasi_event_u {
+    fd_readwrite: __wasi_event_fd_readwrite_t,
+}
+
+#[derive(Copy, Clone)]
+pub enum EventEnum {
+    FdReadWrite {
+        nbytes: __wasi_filesize_t,
+        flags: __wasi_eventrwflags_t,
+    },
+}
+
+impl EventEnum {
+    pub fn untagged(self) -> __wasi_event_u {
+        match self {
+            EventEnum::FdReadWrite { nbytes, flags } => __wasi_event_u {
+                fd_readwrite: __wasi_event_fd_readwrite_t { nbytes, flags },
+            },
+        }
+    }
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct __wasi_event_t {
+    pub userdata: __wasi_userdata_t,
+    pub error: __wasi_errno_t,
+    pub type_: __wasi_eventtype_t,
+    pub u: __wasi_event_u,
+}
+
+impl __wasi_event_t {
+    pub fn tagged(&self) -> Option<EventEnum> {
+        match self.type_ {
+            __WASI_EVENTTYPE_FD_READ | __WASI_EVENTTYPE_FD_WRITE => Some(EventEnum::FdReadWrite {
+                nbytes: unsafe { self.u.fd_readwrite.nbytes },
+                flags: unsafe { self.u.fd_readwrite.flags },
+            }),
+            _ => None,
+        }
+    }
+}
+
+pub type __wasi_eventrwflags_t = u16;
+pub const __WASI_EVENT_FD_READWRITE_HANGUP: u16 = 1 << 0;
+
+pub type __wasi_eventtype_t = u8;
+pub const __WASI_EVENTTYPE_CLOCK: u8 = 0;
+pub const __WASI_EVENTTYPE_FD_READ: u8 = 1;
+pub const __WASI_EVENTTYPE_FD_WRITE: u8 = 2;
+
+pub type __wasi_exitcode_t = u32;
+
+pub type __wasi_fd_t = u32;
+pub const __WASI_STDIN_FILENO: u32 = 0;
+pub const __WASI_STDOUT_FILENO: u32 = 1;
+pub const __WASI_STDERR_FILENO: u32 = 2;
+
+pub type __wasi_fdflags_t = u16;
+pub const __WASI_FDFLAG_APPEND: u16 = 1 << 0;
+pub const __WASI_FDFLAG_DSYNC: u16 = 1 << 1;
+pub const __WASI_FDFLAG_NONBLOCK: u16 = 1 << 2;
+pub const __WASI_FDFLAG_RSYNC: u16 = 1 << 3;
+pub const __WASI_FDFLAG_SYNC: u16 = 1 << 4;
+
+pub type __wasi_preopentype_t = u8;
+pub const __WASI_PREOPENTYPE_DIR: u8 = 0;
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[repr(C)]
+pub struct __wasi_prestat_u_dir_t {
+    pub pr_name_len: u32,
+}
+
+unsafe impl ValueType for __wasi_prestat_u_dir_t {}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub union __wasi_prestat_u {
+    dir: __wasi_prestat_u_dir_t,
+}
+
+impl fmt::Debug for __wasi_prestat_u {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "__wasi_prestat_u")
+    }
+}
+
+unsafe impl ValueType for __wasi_prestat_u {}
+
+#[derive(Debug, Copy, Clone)]
+#[repr(C)]
+pub struct __wasi_prestat_t {
+    pub pr_type: __wasi_preopentype_t,
+    pub u: __wasi_prestat_u,
+}
+
+#[derive(Copy, Clone)]
+pub enum PrestatEnum {
+    Dir { pr_name_len: u32 },
+}
+
+impl PrestatEnum {
+    pub fn untagged(self) -> __wasi_prestat_u {
+        match self {
+            PrestatEnum::Dir { pr_name_len } => __wasi_prestat_u {
+                dir: __wasi_prestat_u_dir_t { pr_name_len },
+            },
+        }
+    }
+}
+
+impl __wasi_prestat_t {
+    pub fn tagged(&self) -> Option<PrestatEnum> {
+        match self.pr_type {
+            __WASI_PREOPENTYPE_DIR => Some(PrestatEnum::Dir {
+                pr_name_len: unsafe { self.u.dir.pr_name_len },
+            }),
+            _ => None,
+        }
+    }
+}
+
+unsafe impl ValueType for __wasi_prestat_t {}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[repr(C)]
+pub struct __wasi_fdstat_t {
+    pub fs_filetype: __wasi_filetype_t,
+    pub fs_flags: __wasi_fdflags_t,
+    pub fs_rights_base: __wasi_rights_t,
+    pub fs_rights_inheriting: __wasi_rights_t,
+}
+
+unsafe impl ValueType for __wasi_fdstat_t {}
+
+pub type __wasi_filedelta_t = i64;
+
+pub type __wasi_filesize_t = u64;
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
+#[repr(C)]
+pub struct __wasi_filestat_t {
+    pub st_dev: __wasi_device_t,
+    pub st_ino: __wasi_inode_t,
+    pub st_filetype: __wasi_filetype_t,
+    pub st_nlink: __wasi_linkcount_t,
+    pub st_size: __wasi_filesize_t,
+    pub st_atim: __wasi_timestamp_t,
+    pub st_mtim: __wasi_timestamp_t,
+    pub st_ctim: __wasi_timestamp_t,
+}
+
+unsafe impl ValueType for __wasi_filestat_t {}
+
+pub type __wasi_filetype_t = u8;
+pub const __WASI_FILETYPE_UNKNOWN: u8 = 0;
+pub const __WASI_FILETYPE_BLOCK_DEVICE: u8 = 1;
+pub const __WASI_FILETYPE_CHARACTER_DEVICE: u8 = 2;
+pub const __WASI_FILETYPE_DIRECTORY: u8 = 3;
+pub const __WASI_FILETYPE_REGULAR_FILE: u8 = 4;
+pub const __WASI_FILETYPE_SOCKET_DGRAM: u8 = 5;
+pub const __WASI_FILETYPE_SOCKET_STREAM: u8 = 6;
+pub const __WASI_FILETYPE_SYMBOLIC_LINK: u8 = 7;
+
+pub type __wasi_fstflags_t = u16;
+pub const __WASI_FILESTAT_SET_ATIM: u16 = 1 << 0;
+pub const __WASI_FILESTAT_SET_ATIM_NOW: u16 = 1 << 1;
+pub const __WASI_FILESTAT_SET_MTIM: u16 = 1 << 2;
+pub const __WASI_FILESTAT_SET_MTIM_NOW: u16 = 1 << 3;
+
+pub type __wasi_inode_t = u64;
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[repr(C)]
+pub struct __wasi_iovec_t {
+    pub buf: WasmPtr<u8, Array>,
+    pub buf_len: u32,
+}
+
+unsafe impl ValueType for __wasi_iovec_t {}
+
+pub type __wasi_linkcount_t = u32;
+
+pub type __wasi_lookupflags_t = u32;
+pub const __WASI_LOOKUP_SYMLINK_FOLLOW: u32 = 1 << 0;
+
+pub type __wasi_oflags_t = u16;
+pub const __WASI_O_CREAT: u16 = 1 << 0;
+pub const __WASI_O_DIRECTORY: u16 = 1 << 1;
+pub const __WASI_O_EXCL: u16 = 1 << 2;
+pub const __WASI_O_TRUNC: u16 = 1 << 3;
+
+pub type __wasi_riflags_t = u16;
+pub const __WASI_SOCK_RECV_PEEK: u16 = 1 << 0;
+pub const __WASI_SOCK_RECV_WAITALL: u16 = 1 << 1;
+
+pub type __wasi_rights_t = u64;
+pub const __WASI_RIGHT_FD_DATASYNC: u64 = 1 << 0;
+pub const __WASI_RIGHT_FD_READ: u64 = 1 << 1;
+pub const __WASI_RIGHT_FD_SEEK: u64 = 1 << 2;
+pub const __WASI_RIGHT_FD_FDSTAT_SET_FLAGS: u64 = 1 << 3;
+pub const __WASI_RIGHT_FD_SYNC: u64 = 1 << 4;
+pub const __WASI_RIGHT_FD_TELL: u64 = 1 << 5;
+pub const __WASI_RIGHT_FD_WRITE: u64 = 1 << 6;
+pub const __WASI_RIGHT_FD_ADVISE: u64 = 1 << 7;
+pub const __WASI_RIGHT_FD_ALLOCATE: u64 = 1 << 8;
+pub const __WASI_RIGHT_PATH_CREATE_DIRECTORY: u64 = 1 << 9;
+pub const __WASI_RIGHT_PATH_CREATE_FILE: u64 = 1 << 10;
+pub const __WASI_RIGHT_PATH_LINK_SOURCE: u64 = 1 << 11;
+pub const __WASI_RIGHT_PATH_LINK_TARGET: u64 = 1 << 12;
+pub const __WASI_RIGHT_PATH_OPEN: u64 = 1 << 13;
+pub const __WASI_RIGHT_FD_READDIR: u64 = 1 << 14;
+pub const __WASI_RIGHT_PATH_READLINK: u64 = 1 << 15;
+pub const __WASI_RIGHT_PATH_RENAME_SOURCE: u64 = 1 << 16;
+pub const __WASI_RIGHT_PATH_RENAME_TARGET: u64 = 1 << 17;
+pub const __WASI_RIGHT_PATH_FILESTAT_GET: u64 = 1 << 18;
+pub const __WASI_RIGHT_PATH_FILESTAT_SET_SIZE: u64 = 1 << 19;
+pub const __WASI_RIGHT_PATH_FILESTAT_SET_TIMES: u64 = 1 << 20;
+pub const __WASI_RIGHT_FD_FILESTAT_GET: u64 = 1 << 21;
+pub const __WASI_RIGHT_FD_FILESTAT_SET_SIZE: u64 = 1 << 22;
+pub const __WASI_RIGHT_FD_FILESTAT_SET_TIMES: u64 = 1 << 23;
+pub const __WASI_RIGHT_PATH_SYMLINK: u64 = 1 << 24;
+pub const __WASI_RIGHT_PATH_UNLINK_FILE: u64 = 1 << 25;
+pub const __WASI_RIGHT_PATH_REMOVE_DIRECTORY: u64 = 1 << 26;
+pub const __WASI_RIGHT_POLL_FD_READWRITE: u64 = 1 << 27;
+pub const __WASI_RIGHT_SOCK_SHUTDOWN: u64 = 1 << 28;
+
+pub type __wasi_roflags_t = u16;
+pub const __WASI_SOCK_RECV_DATA_TRUNCATED: u16 = 1 << 0;
+
+pub type __wasi_sdflags_t = u8;
+pub const __WASI_SHUT_RD: u8 = 1 << 0;
+pub const __WASI_SHUT_WR: u8 = 1 << 1;
+
+pub type __wasi_siflags_t = u16;
+
+pub type __wasi_signal_t = u8;
+pub const __WASI_SIGABRT: u8 = 0;
+pub const __WASI_SIGALRM: u8 = 1;
+pub const __WASI_SIGBUS: u8 = 2;
+pub const __WASI_SIGCHLD: u8 = 3;
+pub const __WASI_SIGCONT: u8 = 4;
+pub const __WASI_SIGFPE: u8 = 5;
+pub const __WASI_SIGHUP: u8 = 6;
+pub const __WASI_SIGILL: u8 = 7;
+pub const __WASI_SIGINT: u8 = 8;
+pub const __WASI_SIGKILL: u8 = 9;
+pub const __WASI_SIGPIPE: u8 = 10;
+pub const __WASI_SIGQUIT: u8 = 11;
+pub const __WASI_SIGSEGV: u8 = 12;
+pub const __WASI_SIGSTOP: u8 = 13;
+pub const __WASI_SIGSYS: u8 = 14;
+pub const __WASI_SIGTERM: u8 = 15;
+pub const __WASI_SIGTRAP: u8 = 16;
+pub const __WASI_SIGTSTP: u8 = 17;
+pub const __WASI_SIGTTIN: u8 = 18;
+pub const __WASI_SIGTTOU: u8 = 19;
+pub const __WASI_SIGURG: u8 = 20;
+pub const __WASI_SIGUSR1: u8 = 21;
+pub const __WASI_SIGUSR2: u8 = 22;
+pub const __WASI_SIGVTALRM: u8 = 23;
+pub const __WASI_SIGXCPU: u8 = 24;
+pub const __WASI_SIGXFSZ: u8 = 25;
+
+pub type __wasi_subclockflags_t = u16;
+pub const __WASI_SUBSCRIPTION_CLOCK_ABSTIME: u16 = 1 << 0;
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[repr(C)]
+pub struct __wasi_subscription_clock_t {
+    pub userdata: __wasi_userdata_t,
+    pub clock_id: __wasi_clockid_t,
+    pub timeout: __wasi_timestamp_t,
+    pub precision: __wasi_timestamp_t,
+    pub flags: __wasi_subclockflags_t,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[repr(C)]
+pub struct __wasi_subscription_fs_readwrite_t {
+    pub fd: __wasi_fd_t,
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub union __wasi_subscription_u {
+    clock: __wasi_subscription_clock_t,
+    fd_readwrite: __wasi_subscription_fs_readwrite_t,
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct __wasi_subscription_t {
+    pub userdata: __wasi_userdata_t,
+    pub type_: __wasi_eventtype_t,
+    pub u: __wasi_subscription_u,
+}
+
+pub enum SubscriptionEnum {
+    Clock(__wasi_subscription_clock_t),
+    FdReadWrite(__wasi_subscription_fs_readwrite_t),
+}
+
+impl __wasi_subscription_t {
+    pub fn tagged(&self) -> Option<SubscriptionEnum> {
+        match self.type_ {
+            __WASI_EVENTTYPE_CLOCK => Some(SubscriptionEnum::Clock(unsafe { self.u.clock })),
+            __WASI_EVENTTYPE_FD_READ | __WASI_EVENTTYPE_FD_WRITE => {
+                Some(SubscriptionEnum::FdReadWrite(unsafe {
+                    self.u.fd_readwrite
+                }))
+            }
+            _ => None,
+        }
+    }
+}
+
+pub type __wasi_timestamp_t = u64;
+
+pub type __wasi_userdata_t = u64;
+
+pub type __wasi_whence_t = u8;
+pub const __WASI_WHENCE_CUR: u8 = 0;
+pub const __WASI_WHENCE_END: u8 = 1;
+pub const __WASI_WHENCE_SET: u8 = 2;

--- a/src/auto_splitting/mod.rs
+++ b/src/auto_splitting/mod.rs
@@ -1,0 +1,103 @@
+use {
+    crate::{timing::SharedTimer, TimeSpan, TimerPhase},
+    crossbeam_channel::{unbounded, Receiver, Sender},
+    livesplit_auto_splitting::{Runtime as ScriptRuntime, TimerAction, TimerState},
+    std::{
+        error::Error,
+        thread::{self, Thread},
+    },
+};
+
+pub struct Runtime {
+    sender: Sender<Request>,
+}
+
+impl Runtime {
+    pub fn new(timer: SharedTimer) -> Self {
+        let (sender, receiver) = unbounded();
+        // TODO: Store the join handle
+        thread::spawn(move || {
+            'back_to_not_having_a_runtime: loop {
+                let mut runtime = loop {
+                    let message = receiver.recv().unwrap(); // TODO: No unwrap
+                    match message {
+                        Request::LoadScript(script) => {
+                            break ScriptRuntime::new(&script).unwrap();
+                            // TODO: Send back result instead of unwrapping
+                        }
+                        Request::UnloadScript => {
+                            // TODO: Nothing to do. Send back a result?
+                        }
+                    }
+                };
+                loop {
+                    // TODO: Handle the different kinds of errors here, such as
+                    // needing to end
+                    if let Ok(message) = receiver.try_recv() {
+                        match message {
+                            Request::LoadScript(script) => {
+                                runtime = ScriptRuntime::new(&script).unwrap();
+                                // TODO: Send back result instead of unwrapping
+                            }
+                            Request::UnloadScript => {
+                                continue 'back_to_not_having_a_runtime;
+                            }
+                        }
+                    }
+                    let phase = timer.read().current_phase();
+                    runtime.set_state(match phase {
+                        TimerPhase::NotRunning => TimerState::NotRunning,
+                        TimerPhase::Running | TimerPhase::Paused => TimerState::Running,
+                        TimerPhase::Ended => TimerState::Finished,
+                    });
+                    // TODO: No unwrap
+                    let action = runtime.step().unwrap();
+                    if let Some(is_loading) = runtime.is_loading() {
+                        if is_loading {
+                            timer.write().pause_game_time();
+                        } else {
+                            timer.write().resume_game_time();
+                        }
+                    }
+                    if let Some(game_time) = runtime.game_time() {
+                        timer
+                            .write()
+                            .set_game_time(TimeSpan::from_seconds(game_time));
+                    }
+                    if let Some(action) = action {
+                        let mut timer = timer.write();
+                        match action {
+                            TimerAction::Start => timer.start(),
+                            TimerAction::Split => timer.split(),
+                            TimerAction::Reset => timer.reset(true),
+                        }
+                    }
+                    runtime.sleep();
+                }
+            }
+        });
+
+        Self { sender }
+    }
+
+    // TODO: Fix this error type
+    // TODO: Futures based API
+    pub fn load_script(&self, script: Vec<u8>) -> Result<(), Box<dyn Error>> {
+        // TODO: unwrap
+        self.sender.send(Request::LoadScript(script)).unwrap();
+        // TODO: receive result
+        Ok(())
+    }
+
+    pub fn unload_script(&self) -> Result<(), Box<dyn Error>> {
+        // TODO: unwrap
+        self.sender.send(Request::UnloadScript).unwrap();
+        // TODO: receive result
+        Ok(())
+    }
+}
+
+enum Request {
+    LoadScript(Vec<u8>),
+    UnloadScript,
+}

--- a/src/auto_splitting/mod.rs
+++ b/src/auto_splitting/mod.rs
@@ -61,6 +61,9 @@ impl Runtime {
                             continue 'back_to_not_having_a_runtime;
                         }
                     };
+                    for (key, value) in runtime.drain_variable_changes() {
+                        timer.write().set_custom_variable(key, value);
+                    }
                     if let Some(is_loading) = runtime.is_loading() {
                         if is_loading {
                             timer.write().pause_game_time();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,8 @@ macro_rules! catch {
 }
 
 pub mod analysis;
+#[cfg(feature = "auto-splitting")]
+pub mod auto_splitting;
 pub mod comparison;
 pub mod component;
 #[cfg(feature = "std")]


### PR DESCRIPTION
~~To achieve feature parity with existing implementation, we still need to implement `Process::with_name`. Either we need to bring in a crate that can do cross-platform process listing, or implement it ourselves with the platform specific APIs.~~

~~`Process::path` is also unimplemented, but I notice that it's currently unused, so I'm not sure how necessary it is.~~

 EDIT: These have now been reimplemented.

I should note that I have only compiled this, I have not tried to run/test this.

I'd also like to comment that some modules are loaded/unloaded dynamically, so we may want to query them on-request, instead of querying them once when we start working with the program. 