### PR TITLE
Auto-splitting for Linux

### DIFF
--- a/crates/livesplit-auto-splitting/Cargo.toml
+++ b/crates/livesplit-auto-splitting/Cargo.toml
@@ -11,4 +11,7 @@ num-traits = "0.2.11"
 num-derive = "0.3.0"
 snafu = "0.6.6"
 wasmtime = { git = "https://github.com/bytecodealliance/wasmtime", default-features = false }
+libc = "0.2.54"
+
+[target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.5", features = ["handleapi", "memoryapi", "processthreadsapi", "psapi", "tlhelp32", "winnt", "wow64apiset"] }

--- a/crates/livesplit-auto-splitting/Cargo.toml
+++ b/crates/livesplit-auto-splitting/Cargo.toml
@@ -11,8 +11,11 @@ num-traits = "0.2.11"
 num-derive = "0.3.0"
 snafu = "0.6.6"
 wasmtime = { git = "https://github.com/bytecodealliance/wasmtime", default-features = false }
-libc = "0.2.54"
 bytemuck = "1.2.0"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.5", features = ["handleapi", "memoryapi", "processthreadsapi", "psapi", "tlhelp32", "winnt", "wow64apiset"] }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+nom = "5.1.1"
+libc = "0.2.54"

--- a/crates/livesplit-auto-splitting/Cargo.toml
+++ b/crates/livesplit-auto-splitting/Cargo.toml
@@ -12,6 +12,7 @@ num-derive = "0.3.0"
 snafu = "0.6.6"
 wasmtime = { git = "https://github.com/bytecodealliance/wasmtime", default-features = false }
 libc = "0.2.54"
+bytemuck = "1.2.0"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.5", features = ["handleapi", "memoryapi", "processthreadsapi", "psapi", "tlhelp32", "winnt", "wow64apiset"] }

--- a/crates/livesplit-auto-splitting/src/process/linux.rs
+++ b/crates/livesplit-auto-splitting/src/process/linux.rs
@@ -1,0 +1,192 @@
+use libc::pid_t;
+use std::os::unix::ffi::OsStringExt;
+use std::ffi::{OsStr, OsString};
+use std::fs::File;
+use std::path::PathBuf;
+use std::str::FromStr;
+use std::{mem, slice, fs, io};
+use std::io::{Read, BufRead};
+use std::collections::HashMap;
+
+use super::{Error, Result, Address, Offset, Signature};
+
+#[derive(Debug, Clone)]
+pub struct Process {
+    pid: pid_t,
+    is_64bit: bool
+}
+
+struct MapRange {
+    range_start: Address,
+    range_end: Address,
+    offset: Offset,
+    path: Option<PathBuf>,
+    perms: [u8; 4]
+}
+
+impl Process {
+    pub fn is_64bit(&self) -> bool {
+        self.is_64bit
+    }
+
+    fn process_name(&self) -> Option<OsString> {
+        let mut process_name = Vec::new();
+        File::open(format!("/proc/{}/comm", self.pid)).ok()?.read_to_end(&mut process_name).ok()?;
+
+        Some(OsString::from_vec(process_name))
+    }
+
+    // fn handle(&self) -> pid_t {
+    //     self.pid
+    // }
+
+    // Autosplitter/user should probably get access to this list to choose from it in the future.
+    fn processes_with_name(name: &OsStr) -> Result<Vec<Self>> {
+        // License: MIT
+        // Copyright (c) 2015 Guillaume Gomez
+        // Based on https://github.com/GuillaumeGomez/sysinfo/blob/4edbf34ad5fcd03979498ec124e15a067c10d0b4/src/linux/system.rs#L512
+        let dir = fs::read_dir("/proc").or(Err(Error::ListProcesses))?;
+        let processes = dir.filter_map(std::result::Result::ok)
+            .filter(|e| e.path().is_dir())
+            .filter_map(|e| e.path().file_name().and_then(OsStr::to_str).map(pid_t::from_str))
+            .filter_map(std::result::Result::ok)
+            .map(Process::with_pid)
+            .filter_map(std::result::Result::ok)
+            .filter(|proc| {
+                if let Some(process_name) = proc.process_name() {
+                    &*process_name == name
+                } else {
+                    false
+                }
+            })
+            // TODO: sort
+            .collect();
+
+        Ok(processes)
+    }
+
+    pub fn with_name<T: AsRef<OsStr>>(name: T) -> Result<Self> {
+        Process::processes_with_name(name.as_ref())?.get(0).cloned().ok_or(Error::ProcessDoesntExist)
+    }
+
+    pub fn with_pid(pid: libc::pid_t) -> Result<Self> {
+        let mut proc = Process { pid, is_64bit: false };
+        // TODO: do we want to cache the pages/modules at all?
+        if let Ok(pages) = proc.memory_pages() {
+            // Inspired by https://unix.stackexchange.com/a/106235 "Parsing the maps file"
+            proc.is_64bit = pages.last().unwrap().range_end > 0xFFFFFFFF;
+            Ok(proc)
+        } else {
+            Err(Error::ProcessDoesntExist)
+        }
+    }
+
+    pub fn module_address<T: AsRef<OsStr>>(&self, module: T) -> Result<Address> {
+        self.modules()?.get(module.as_ref()).cloned().ok_or(Error::ModuleDoesntExist)
+    }
+
+    pub fn modules(&self) -> Result<HashMap<OsString, Address>> {
+        // There are multiple ways of doing this. Could also traverse symlinks in /proc/PID/map_files, for instance
+        Ok(self.memory_pages()?.filter_map(|MapRange { path, range_start, offset, .. }|
+            path.map(|p|
+                (p.file_name().unwrap().to_os_string(), range_start - offset as Address)
+            )
+        ).collect())
+    }
+
+    pub fn read_buf(&self, address: Address, buf: &mut [u8]) -> Result<()> {
+        use libc::{pid_t, c_void, iovec, process_vm_readv};
+
+        // TODO: what if this is a 32 bit process and we're trying to read from a 64 bit process?
+        // Should we go through /proc/PID/mem instead? ptrace?
+        // TODO: What's required so we don't need to run as root?
+        let local_iov = iovec {
+            iov_base: buf.as_mut_ptr() as *mut c_void,
+            iov_len: buf.len()
+        };
+
+        let remote_iov = iovec {
+            iov_base: address as *mut c_void,
+            iov_len: buf.len()
+        };
+
+        let result = unsafe { process_vm_readv(self.pid, &local_iov, 1, &remote_iov, 1, 0) };
+        if result == -1 {
+            Err(Error::ReadMemory)
+        } else {
+            Ok(())
+        }
+    }
+
+    // TODO: move to shared helper
+    pub fn read<T: Copy>(&self, address: Address) -> Result<T> {
+        // TODO Unsound af
+        unsafe {
+            let mut res = mem::uninitialized();
+            let buf = slice::from_raw_parts_mut(mem::transmute(&mut res), mem::size_of::<T>());
+            self.read_buf(address, buf).map(|_| res)
+        }
+    }
+
+    // Parses /proc/PID/maps
+    fn memory_pages(&self) -> Result<impl Iterator<Item=MapRange>> {
+        // License: MIT
+        // Copyright (c) 2016 Julia Evans, Jorge Aparicio
+        // Based on https://github.com/rbspy/proc-maps/blob/7168cd0a13d464ef00f20a81f064b7729ff58d2e/src/linux_maps.rs#L49
+        let file = io::BufReader::new(File::open(format!("/proc/{}/maps", self.pid)).or(Err(Error::ProcessDoesntExist))?);
+        // TODO: use OsString, use unwrap a bit less.
+        Ok(file.lines().filter_map(std::result::Result::ok).map(|line| {
+            let mut fields = line.split_whitespace();
+
+            let mut range = fields.next().unwrap().split('-');
+            let range_start = Address::from_str_radix(range.next().unwrap(), 16).unwrap();
+            let range_end = Address::from_str_radix(range.next().unwrap(), 16).unwrap();
+
+            let perms = fields.next().unwrap().as_bytes();
+            let perms: [u8; 4] = [perms[0], perms[1], perms[2], perms[3]];
+
+            let offset = Offset::from_str_radix(fields.next().unwrap(), 16).unwrap();
+
+            let _ = fields.next(); // dev
+            let _ = fields.next(); // inode
+
+            let path: Option<PathBuf> = fields.next().map(|s| s.into());
+
+            MapRange {
+                range_start,
+                range_end,
+                offset,
+                perms,
+                path
+            }
+        }))
+    }
+
+    // TODO: move to shared helper
+    pub fn scan_signature(&self, signature: &str) -> Result<Option<Address>> {
+        let signature = Signature::new(signature);
+
+        let mut page_buf = Vec::<u8>::new();
+
+        for page in self.memory_pages()?
+            .filter(|range| range.perms[0] == b'r' && !(range.path.is_some() && (
+                range.path.as_ref().unwrap().starts_with("/dev") ||
+                range.path.as_ref().unwrap().file_name().unwrap() == "[vvar]" ||
+                range.path.as_ref().unwrap().file_name().unwrap() == "[vdso]"
+            )))
+        {
+            let base = page.range_start;
+            let len = page.range_end - page.range_start;
+            page_buf.clear();
+            page_buf.reserve(len as usize);
+            unsafe {
+                page_buf.set_len(len as usize);
+                self.read_buf(base, &mut page_buf)?;
+            }
+            if let Some(index) = signature.scan(&page_buf) {
+                return Ok(Some(base + index as Address));
+            }
+        }
+        Ok(None)
+    }
+}

--- a/crates/livesplit-auto-splitting/src/process/linux.rs
+++ b/crates/livesplit-auto-splitting/src/process/linux.rs
@@ -5,7 +5,7 @@ use std::ffi::{OsStr, OsString};
 use std::fs::File;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
-use std::{mem, slice, fs, io};
+use std::{fs, io};
 use std::io::{Read, BufRead};
 use std::collections::HashMap;
 use std::cell::{RefCell, RefMut};
@@ -15,7 +15,7 @@ use nom::sequence::{tuple, separated_pair, terminated};
 use nom::combinator::{map, map_res, opt, verify};
 use nom::IResult;
 
-use super::{Error, Result, Address, Offset, Signature, ProcessImpl, ScannableRange};
+use super::{Error, Result, Address, ProcessImpl, ScannableRange};
 
 #[derive(Debug)]
 pub struct Process {
@@ -118,8 +118,6 @@ impl ProcessImpl for Process {
     }
 
     fn read_buf(&self, address: Address, buf: &mut [u8]) -> Result<()> {
-        use libc::{pid_t, c_void, iovec, process_vm_readv};
-
         if let Some(file) = self.memory() {
             file.read_exact_at(buf, address as u64).or(Err(Error::ReadMemory))
         } else {

--- a/crates/livesplit-auto-splitting/src/process/mod.rs
+++ b/crates/livesplit-auto-splitting/src/process/mod.rs
@@ -5,7 +5,7 @@ mod os;
 pub use os::Process;
 
 use std::ffi::OsStr;
-use std::{io, slice, mem};
+use std::mem;
 use bytemuck::Pod;
 
 #[derive(Debug, snafu::Snafu)]

--- a/crates/livesplit-auto-splitting/src/process/mod.rs
+++ b/crates/livesplit-auto-splitting/src/process/mod.rs
@@ -1,0 +1,94 @@
+#[cfg_attr(linux, path = "linux.rs")]
+#[cfg_attr(windows, path = "windows.rs")]
+mod os;
+
+pub use os::Process;
+
+#[derive(Debug, snafu::Snafu)]
+pub enum Error {
+    // TODO: Doc Comments
+    ListProcesses,
+    ProcessDoesntExist,
+    ListModules,
+    ProcessOpening,
+    ModuleDoesntExist,
+    ReadMemory,
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+pub type Address = u64;
+pub type Offset = i64;
+
+pub(crate) struct Signature {
+    bytes: Vec<u8>,
+    mask: Vec<bool>,
+    skip_offsets: [usize; 256],
+}
+
+impl Signature {
+    pub(crate) fn new(signature: &str) -> Self {
+        let mut bytes_iter = signature.bytes().filter_map(|b| match b {
+            b'0'..=b'9' => Some(b - b'0'),
+            b'a'..=b'f' => Some(b - b'a' + 0xA),
+            b'A'..=b'F' => Some(b - b'A' + 0xA),
+            b'?' => Some(0x10),
+            _ => None,
+        });
+        let (mut bytes, mut mask) = (Vec::new(), Vec::new());
+
+        while let (Some(a), Some(b)) = (bytes_iter.next(), bytes_iter.next()) {
+            let sig_byte = (a << 4) | b;
+            let is_question_marks = a == 0x10 && b == 0x10;
+            bytes.push(sig_byte);
+            mask.push(is_question_marks);
+        }
+
+        let mut skip_offsets = [0; 256];
+
+        let mut unknown = 0;
+        let end = bytes.len() - 1;
+        for (i, (&byte, mask)) in bytes.iter().zip(&mask).enumerate().take(end) {
+            if !mask {
+                skip_offsets[byte as usize] = end - i;
+            } else {
+                unknown = end - i;
+            }
+        }
+
+        if unknown == 0 {
+            unknown = bytes.len();
+        }
+
+        for offset in &mut skip_offsets[..] {
+            if unknown < *offset || *offset == 0 {
+                *offset = unknown;
+            }
+        }
+
+        Self {
+            bytes,
+            mask,
+            skip_offsets,
+        }
+    }
+
+    pub(crate) fn scan(&self, buf: &[u8]) -> Option<usize> {
+        let mut current = 0;
+        let end = self.bytes.len() - 1;
+        while current <= buf.len() - self.bytes.len() {
+            let rem = &buf[current..];
+            if rem
+                .iter()
+                .zip(&self.bytes)
+                .zip(&self.mask)
+                .all(|((&buf, &search), &mask)| buf == search || mask)
+            {
+                return Some(current);
+            }
+            let offset = self.skip_offsets[rem[end] as usize];
+            current += offset;
+        }
+        None
+    }
+}


### PR DESCRIPTION
After discussion in discord where it was noted that the external crates I chose to use in #1 were unmaintained, it was decided to pull the relevant code into our crate. So, this is a re-written (and up to date) version of #1.

~~Still TODO~~ unchecked items have been punted for now to future PRs:
 - [ ] The current implementation effectively requires running as root, even for processes owned by the local user.
   - there is a commonly set mitigation nowadays that only parent processes can ptrace/read memory from a process. So, if we launch the game via livesplit (or some helper program), it'd (probably) work.
 - [x] ~~Process::scan_signature is mostly code that can be shared between the platforms, but it needs to have access to OS specific things for listing memory pages.~~
 - [x] ~~Process::read is unsound.~~ using bytemuck
 - [x] ~~Linux: /proc/PID/maps is parsed line by line as a String, because it was far more convienent to do so. This should not be passing through String as it is not guaranteed to be UTF-8.~~ Using nom instead (for now)
 - [ ] Reading memory of a 64 bit process from a 32 bit process will currently fail in both implementations. Granted, wasmtime currently fails to build for i686 targets.
   - [ ] Windows: ReadMemory takes pointer of native size
     - https://stackoverflow.com/a/36798492. In short, the 64bit version of ntdll is also loaded in WOW64 processes, so we can call the 64 bit version of ReadMemory. This might fail on Windows installed as 32bit, though.
   - [x] ~~Linux: process_vm_readv takes pointer of native size~~ using /proc/pid/mem instead.
 - Autosplitter API (can wait for another PR or something)
  - env::read_into_buf should *really* return an errorcode if it isn't already.
  - set_process_name is somewhat insufficient for autosplitters that want to be able to run for e.g. "hl2.exe", "hl2_linux", "portal2.exe", and "portal2_linux".
 - I may take the time to implement more platforms, but I would be completely unable to test them.
 - process::Error is... not a particularly useful error type in it's current iteration.